### PR TITLE
Add a more detailed setup.py for upload to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,22 @@
 from setuptools import setup, find_packages
 
-setup(name="troi", packages=find_packages())
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="troi",
+    version="0.0.1pre",
+    author="MetaBrainz Foundation",
+    description="An empathetic music recommendation system pipeline",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/metabrainz/troi-recommendation-playground",
+    install_requires=["click>=7", "ujson>=2", "requests>=2.24", "pylistenbrainz", "openpost"],
+    packages=find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.8',
+)


### PR DESCRIPTION
LB-739
This is an initial version of setup.py that allows us to upload troi to pypi. We should still address some of the points raised in the above ticket in the future.