### PR TITLE
LB-742: command-line interface to debug a single element

### DIFF
--- a/troi/cli.py
+++ b/troi/cli.py
@@ -80,6 +80,19 @@ def list_patches():
         print("  %s: %s" % (slug, patches[slug]().description()))
 
 
+@cli.command(context_settings=dict(
+    ignore_unknown_options=True,
+))
+@click.argument('element_name',)
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
+def debug(element_name, args):
+    """Debug an element"""
+    element = troi.utils.load_element(element_name)
+    input = element.generate_debug_input(list(args))
+    data = element().read([input], debug=True)
+    element.debug_print_response(data)
+
+
 @cli.command()
 @click.argument("patch", nargs=1)
 def info(patch):

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -22,6 +22,15 @@ class RecordingLookupElement(Element):
     def outputs():
         return [ Recording ]
 
+    @staticmethod
+    def generate_debug_input(inputs):
+        return [Recording(mbid=inputs[0])]
+
+    @staticmethod
+    def debug_print_response(data):
+        for recording in data:
+            print(recording, recording.mbid, recording.musicbrainz)
+
     def read(self, inputs, debug=False):
 
         recordings = inputs[0]

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -18,6 +18,17 @@ def discover_patches():
     return  {**patches, **local_patches}
 
 
+def load_element(element_name):
+    parts = element_name.split(".")
+    module = ".".join(parts[:-1])
+    classname = parts[-1]
+    loaded_module = importlib.import_module(module)
+    class_ = getattr(loaded_module, classname)
+    if not class_:
+        raise ImportError(f"No such module {element_name}")
+    return class_
+
+
 def discover_patches_from_dir(module_path, patch_dir, add_dot=False):
     """
         Load patches given the appropriate python module path and then file system path. 


### PR DESCRIPTION
This is a proposal for an interface to be able to debug a single element.

The idea is that I want to be able to check that the `read` method for a single element does the correct thing given its input.

As an example, I can run this:
```
$ python -m troi.cli debug troi.musicbrainz.recording_lookup.RecordingLookupElement 9b5de769-81c7-42f3-b557-8935b87bde5e
- debug 1 recordings
- debug 1 rows in response
<Recording('Glory Box', 145f5c43-0ac2-4886-8b09-63d0e92ded5d, None)> 145f5c43-0ac2-4886-8b09-63d0e92ded5d {}
```

and get an isolated debug output, without having to either use a python console (this is problematic because you have to quit/restart or reload the module when you make a change), or run on a full pipeline (where there might be lots of things happening before or after an element that prevent you from debugging well)

I consider this separate to tests because we're mostly using mocks for remote data in the mocks, and sometimes I want to run an element with real data.

I'm unsure at the moment if it's necessary to provide a way to pass arguments to the Element constructor (e.g. many of the filter Elements take options when it's constructed). We should have a default `generate_debug_input` that raises an error int he case that an Element doesn't implement it