### PR TITLE
Use request's params argument instead of encoding manually

### DIFF
--- a/troi/musicbrainz/artist_credit_id_lookup.py
+++ b/troi/musicbrainz/artist_credit_id_lookup.py
@@ -1,7 +1,3 @@
-import sys
-import urllib
-from urllib.parse import quote
-
 import requests
 import ujson
 
@@ -34,9 +30,8 @@ class ArtistCreditIdLookupElement(Element):
             ac_ids.append(str(a.artist_credit_id))
             index[a.artist_credit_id] = a
 
-        url = self.SERVER_URL + "?[artist_credit_id]=" + quote(",".join(ac_ids))
-
-        r = requests.get(url)
+        params = {"[artist_credit_id]": ",".join(ac_ids)}
+        r = requests.get(self.SERVER_URL, params=params)
         if r.status_code != 200:
             raise PipelineError("Cannot fetch artist credits from ListenBrainz: HTTP code %d" % r.status_code)
 

--- a/troi/musicbrainz/msb_mapping.py
+++ b/troi/musicbrainz/msb_mapping.py
@@ -1,7 +1,3 @@
-import sys
-import urllib
-from urllib.parse import quote
-
 import requests
 import ujson
 
@@ -33,10 +29,9 @@ class MSBMappingLookupElement(Element):
         artists = ",".join([ r.artist.name for r in in_recordings ])
         recordings = ",".join([ r.name for r in in_recordings ])
 
-        url = self.SERVER_URL + "?[msb_artist_credit_name]=" + quote(artists) + \
-            "&[msb_recording_name]=" + quote(recordings)
-
-        r = requests.get(url)
+        params = {"[msb_artist_credit_name]": artists,
+                  "[msb_recording_name]": recordings}
+        r = requests.get(self.SERVER_URL, params=params)
         if r.status_code != 200:
             raise PipelineError("Cannot fetch MSB mapping rows from ListenBrainz: HTTP code %d" % r.status_code)
 

--- a/troi/musicbrainz/related_artist_credits.py
+++ b/troi/musicbrainz/related_artist_credits.py
@@ -1,8 +1,5 @@
-import sys
-import urllib
 import copy
 from collections import defaultdict
-from urllib.parse import quote
 
 import requests
 import ujson
@@ -32,10 +29,9 @@ class RelatedArtistCreditsElement(Element):
 
         artists = inputs[0]
         ac_ids = ",".join([ str(a.artist_credit_id) for a in artists ])
-        url = self.SERVER_URL + "?[artist_credit_id]=" + quote(ac_ids) + \
-            "&threshold=%d" % self.threshold
-
-        r = requests.get(url)
+        params = {"[artist_credit_id]": ac_ids,
+                  "threshold": self.threshold}
+        r = requests.get(self.SERVER_URL, params=params)
         if r.status_code != 200:
             raise PipelineError("Cannot fetch related artist credits from ListenBrainz: HTTP code %d" % r.status_code)
 


### PR DESCRIPTION
Quick fix to use `params` to pass in a dict of query parameters instead of constructing it manually:

* Requests quotes things for you, so `quote()` isn't needed
* Easier to change parameters if needed without having to faff about with ? and &
* use `r.url` after the request has been made to see the full url with query params if needed