### PR TITLE
Code cleanup / linting

### DIFF
--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -11,20 +11,17 @@ class Element(ABC):
         self.sources = []
         self.logger = logging.getLogger(type(self).__name__)
 
-
     def log(self, msg):
         '''
             Log a message with the info log level, which is the default for troi.
         '''
         self.logger.info(msg)
 
-
     def debug(self, msg):
         '''
             Log a message with debug log level. These messages will only be shown when debugging is enabled.
         '''
         self.logger.debug(msg)
-
 
     def set_sources(self, sources):
         """
@@ -121,13 +118,13 @@ class Entity(ABC):
         of an artist or the listenbrainz dict might contain the BPM for a track.
         How exactly these dicts will be organized is TDB.
     """
-    def __init__(self, ranking=None, musicbrainz={}, listenbrainz={}, acousticbrainz={}):
+    def __init__(self, ranking=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
         self.name = None
         self.mbid = None
         self.msid = None
-        self.musicbrainz = musicbrainz
-        self.listenbrainz = listenbrainz
-        self.acousticbrainz = acousticbrainz
+        self.musicbrainz = musicbrainz or {}
+        self.listenbrainz = listenbrainz or {}
+        self.acousticbrainz = acousticbrainz or {}
         self.notes = []
         self.ranking = ranking
 
@@ -171,7 +168,7 @@ class Artist(Entity):
         The class that represents an artist.
     """
     def __init__(self, name=None, mbids=None, msid=None, artist_credit_id=None,
-                 ranking=None, musicbrainz={}, listenbrainz={}, acousticbrainz={}):
+                 ranking=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.artist_credit_id = artist_credit_id
@@ -192,7 +189,7 @@ class Release(Entity):
         The class that represents a release.
     """
     def __init__(self, name=None, mbid=None, msid=None, artist=None,
-                  ranking=None, musicbrainz={}, listenbrainz={}, acousticbrainz={}):
+                 ranking=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.artist = artist
         self.name = name
@@ -208,7 +205,7 @@ class Recording(Entity):
         The class that represents a recording.
     """
     def __init__(self, name=None, mbid=None, msid=None, length=None, artist=None, release=None,
-                 ranking=None, year=None, musicbrainz={}, listenbrainz={}, acousticbrainz={}):
+                 ranking=None, year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.length = length # track length in ms
         self.artist = artist

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -97,7 +97,7 @@ class Element(ABC):
         return None
 
     @abstractmethod
-    def read(self, source_data_list, debug):
+    def read(self, source_data_list):
         '''
             This method is where the action happens -- when the consumer wants to
             read data from the pipeline, it calls read() on the last element in

--- a/troi/filters.py
+++ b/troi/filters.py
@@ -89,7 +89,7 @@ class ArtistCreditLimiterElement(troi.Element):
         for rec in recordings:
             try:
                 ac_index[rec.artist.artist_credit_id].append((rec.mbid, rec.ranking))
-                if rec.ranking == None:
+                if rec.ranking is None:
                     all_have_rankings = False
             except KeyError:
                 raise RuntimeError(self.__name__ + " needs to have all input recordings to have artist.artist_credit_id defined!")

--- a/troi/filters.py
+++ b/troi/filters.py
@@ -3,6 +3,7 @@ from operator import itemgetter
 from random import shuffle
 
 import troi
+from troi import Recording
 
 
 class ArtistCreditFilterElement(troi.Element):

--- a/troi/filters.py
+++ b/troi/filters.py
@@ -81,7 +81,7 @@ class ArtistCreditLimiterElement(troi.Element):
     def outputs():
         return [Recording]
 
-    def read(self, inputs, debug=False):
+    def read(self, inputs):
 
         recordings = inputs[0]
         ac_index = defaultdict(list)

--- a/troi/listenbrainz/area_random_recordings.py
+++ b/troi/listenbrainz/area_random_recordings.py
@@ -1,7 +1,3 @@
-import sys
-import uuid
-from urllib.parse import quote
-
 import requests
 import ujson
 

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -31,7 +31,6 @@ class UserRecordingRecommendationsElement(Element):
 
     def read(self, inputs = []):
         recording_list = []
-        recordings = []
 
         remaining = self.MAX_RECORDINGS_TO_FETCH if self.count < 0 else self.count
         while True:

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -1,6 +1,5 @@
 import requests
-import ujson
-from troi import Element, Artist, Release, Recording, PipelineError
+from troi import Element, Recording, PipelineError
 import pylistenbrainz
 import pylistenbrainz.errors
 

--- a/troi/listenbrainz/stats.py
+++ b/troi/listenbrainz/stats.py
@@ -1,6 +1,3 @@
-
-import requests
-import ujson
 from troi import Element, Artist, Release, Recording
 import pylistenbrainz
 

--- a/troi/listenbrainz/stats.py
+++ b/troi/listenbrainz/stats.py
@@ -18,7 +18,7 @@ class UserArtistsElement(Element):
     def outputs(self):
         return [Artist]
 
-    def read(self, inputs = [], debug=False):
+    def read(self, inputs = []):
 
         artist_list = []
         artists = self.client.get_user_artists(self.user_name, self.count, self.offset, self.time_range)
@@ -44,7 +44,7 @@ class UserReleasesElement(Element):
     def outputs(self):
         return [Release]
 
-    def read(self, inputs = [], debug=False):
+    def read(self, inputs = []):
 
         release_list = []
         releases = self.client.get_user_releases(self.user_name, self.count, self.offset, self.time_range)
@@ -72,7 +72,7 @@ class UserRecordingElement(Element):
     def outputs(self):
         return [Recording]
 
-    def read(self, inputs = [], debug=False):
+    def read(self, inputs = []):
         recording_list = []
         recordings = self.client.get_user_recordings(self.user_name, self.count, self.offset, self.time_range)
         for r in recordings['payload']['recordings']:

--- a/troi/listenbrainz/tests/test_area_random_recordings.py
+++ b/troi/listenbrainz/tests/test_area_random_recordings.py
@@ -1,5 +1,4 @@
 import json
-import os
 import unittest
 import unittest.mock
 

--- a/troi/listenbrainz/tests/test_recs.py
+++ b/troi/listenbrainz/tests/test_recs.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import unittest
 from unittest.mock import patch
 
-import ujson
-from troi import Artist, Release, Recording
+from troi import Recording
 import troi.listenbrainz.recs
 
 recording_ret = {

--- a/troi/listenbrainz/tests/test_stats.py
+++ b/troi/listenbrainz/tests/test_stats.py
@@ -73,7 +73,7 @@ class TestStats(unittest.TestCase):
         stats_mock.assert_called_with("rob", 1, 1, "week")
         assert len(entities) == 1
         assert isinstance(entities[0], Artist)
-        assert entities[0].mbids == None
+        assert entities[0].mbids is None
         assert entities[0].msid == '7f65aec5-e7a7-4cfa-a6e5-e93e66a04990'
         assert entities[0].name == 'Pretty Lights'
 

--- a/troi/listenbrainz/tests/test_stats.py
+++ b/troi/listenbrainz/tests/test_stats.py
@@ -1,8 +1,6 @@
-import os
 import unittest
 from unittest.mock import patch
 
-import ujson
 from troi import Artist, Release, Recording
 import troi.listenbrainz.stats
 

--- a/troi/musicbrainz/artist_credit_id_lookup.py
+++ b/troi/musicbrainz/artist_credit_id_lookup.py
@@ -15,11 +15,11 @@ class ArtistCreditIdLookupElement(Element):
         super().__init__()
 
     @staticmethod
-    def inputs(self):
+    def inputs():
         return [Artist]
 
     @staticmethod
-    def outputs(self):
+    def outputs():
         return [Artist]
 
     def read(self, inputs):

--- a/troi/musicbrainz/msb_mapping.py
+++ b/troi/musicbrainz/msb_mapping.py
@@ -1,7 +1,7 @@
 import requests
 import ujson
 
-from troi import Element, Release, PipelineError
+from troi import Element, Recording, Release, PipelineError
 
 
 class MSBMappingLookupElement(Element):

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -29,7 +29,6 @@ class RecordingLookupElement(Element):
             return []
 
         data = []
-        r_mbids = ",".join([ r.mbid for r in recordings ])
         for r in recordings:
             data.append({ '[recording_mbid]': r.mbid })
 

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -1,11 +1,8 @@
-import sys
-import uuid
-from urllib.parse import quote
-
 import requests
 import ujson
 
-from troi import Element, Artist, Recording
+from troi import Element, Artist, PipelineError, Recording
+
 
 class RecordingLookupElement(Element):
     '''

--- a/troi/musicbrainz/related_artist_credits.py
+++ b/troi/musicbrainz/related_artist_credits.py
@@ -2,9 +2,8 @@ import copy
 from collections import defaultdict
 
 import requests
-import ujson
 
-from troi import Element, Release, PipelineError
+from troi import Element, Recording, PipelineError
 
 
 class RelatedArtistCreditsElement(Element):

--- a/troi/musicbrainz/tests/test_ac_id_lookup.py
+++ b/troi/musicbrainz/tests/test_ac_id_lookup.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import unittest.mock
 

--- a/troi/musicbrainz/tests/test_msb_mapping.py
+++ b/troi/musicbrainz/tests/test_msb_mapping.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import unittest.mock
 

--- a/troi/musicbrainz/tests/test_recording_lookup.py
+++ b/troi/musicbrainz/tests/test_recording_lookup.py
@@ -1,5 +1,4 @@
 import json
-import os
 import unittest
 import unittest.mock
 

--- a/troi/musicbrainz/tests/test_related_artist_credits.py
+++ b/troi/musicbrainz/tests/test_related_artist_credits.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import unittest.mock
 

--- a/troi/operations.py
+++ b/troi/operations.py
@@ -48,7 +48,7 @@ class UniqueElement(troi.Element):
     def inputs():
         return []
 
-    def read(self, entities_arg, debug=False):
+    def read(self, entities_arg):
         entities = entities_arg[0]
 
         if not entities:
@@ -85,7 +85,7 @@ class UnionElement(troi.Element):
     def inputs(self):
         return []
 
-    def read(self, entities, debug=False):
+    def read(self, entities):
         entities_0 = entities[0]
         entities_1 = entities[1]
 
@@ -115,7 +115,7 @@ class IntersectionElement(troi.Element):
     def inputs(self):
         return []
 
-    def read(self, entities, debug=False):
+    def read(self, entities):
         entities_0 = entities[0]
         entities_1 = entities[1]
 

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -66,7 +66,7 @@ class Patch(ABC):
         return None
 
     @abstractmethod
-    def create(input_args):
+    def create(self, input_args):
         '''
             The function creates the data pipeline and then returns it.
         '''

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -1,8 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
 
-import troi
-
 
 class Patch(ABC):
 

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -1,5 +1,4 @@
 import datetime
-import requests.exceptions
 
 from troi import Recording
 import troi.listenbrainz.area_random_recordings

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -66,7 +66,7 @@ class DailyJamsPatch(troi.patch.Patch):
         type = inputs[1]
         try:
             day = inputs[2]
-            if day == None:
+            if day is None:
                 day = 0
         except IndexError:
             day = 0

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -14,7 +14,7 @@ class PlaylistElement(troi.Element):
         self.entities = None
 
     @staticmethod
-    def inputs(self):
+    def inputs():
         return [Recording]
 
     @property
@@ -43,12 +43,10 @@ class PlaylistElement(troi.Element):
                 }
             })
 
-
         self.entities = entities
         self.playlist = ujson.dumps(listens, indent=4, sort_keys=True)
 
         return entities
-
 
     def print(self):
 
@@ -70,7 +68,6 @@ class PlaylistElement(troi.Element):
             else:
                 rec_name = recording.name
             print("%-60s %-50s" % (rec_name[:59], artist[:49]))
-
 
     def launch(self):
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -1,7 +1,7 @@
-import subprocess
 import ujson
 import openpost
 
+from troi import Recording
 from troi.operations import is_homogeneous
 import troi
 

--- a/troi/tests/test_entities.py
+++ b/troi/tests/test_entities.py
@@ -8,10 +8,10 @@ class TestEntities(unittest.TestCase):
     def test_artist(self):
 
         a = Artist()
-        assert a.mbids == None
-        assert a.msid == None
-        assert a.name == None
-        assert a.artist_credit_id == None
+        assert a.mbids is None
+        assert a.msid is None
+        assert a.name is None
+        assert a.artist_credit_id is None
         with self.assertRaises(TypeError):
             a = Artist(mbids="not a list")
 
@@ -33,16 +33,16 @@ class TestEntities(unittest.TestCase):
         assert a.lb[1] == 2
         assert a.mb[3] == 4
         assert a.ab[5] == 6
-        assert a.name == None
-        assert a.mbid == None
-        assert a.msid == None
+        assert a.name is None
+        assert a.mbid is None
+        assert a.msid is None
 
     def test_release(self):
 
         r = Release()
-        assert r.mbid == None
-        assert r.msid == None
-        assert r.name == None
+        assert r.mbid is None
+        assert r.msid is None
+        assert r.name is None
 
         r = Release("Dummy", "8fe3f1d4-b6d5-4726-89ad-926e3420b9e3", "97b01626-65fc-4c32-b30c-c4d7eab1b339", ranking=.5)
         assert r.name == "Dummy"
@@ -54,16 +54,16 @@ class TestEntities(unittest.TestCase):
         assert r.lb[1] == 2
         assert r.mb[3] == 4
         assert r.ab[5] == 6
-        assert r.name == None
-        assert r.mbid == None
-        assert r.msid == None
+        assert r.name is None
+        assert r.mbid is None
+        assert r.msid is None
 
     def test_recording(self):
 
         r = Recording()
-        assert r.mbid == None
-        assert r.msid == None
-        assert r.name == None
+        assert r.mbid is None
+        assert r.msid is None
+        assert r.name is None
 
         r = Recording("Strangers", "8fe3f1d4-b6d5-4726-89ad-926e3420b9e3", 
                       "97b01626-65fc-4c32-b30c-c4d7eab1b339", ranking=.1, year=1995)
@@ -77,6 +77,6 @@ class TestEntities(unittest.TestCase):
         assert r.lb[1] == 2
         assert r.mb[3] == 4
         assert r.ab[5] == 6
-        assert r.name == None
-        assert r.mbid == None
-        assert r.msid == None
+        assert r.name is None
+        assert r.mbid is None
+        assert r.msid is None

--- a/troi/tests/test_entities.py
+++ b/troi/tests/test_entities.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from troi import Artist, Release, Recording

--- a/troi/tests/test_filters.py
+++ b/troi/tests/test_filters.py
@@ -1,7 +1,6 @@
-import os
 import unittest
 
-from troi import Artist, Release, Recording
+from troi import Artist, Recording
 import troi.filters 
 
 

--- a/troi/tests/test_operations.py
+++ b/troi/tests/test_operations.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from troi import Artist, Release, Recording

--- a/troi/tools/area_lookup.py
+++ b/troi/tools/area_lookup.py
@@ -1,11 +1,7 @@
-import sys
-import uuid
-from urllib.parse import quote
-
 import requests
 import ujson
 
-from troi import Element, Artist, Recording, PipelineError
+from troi import PipelineError
 
 AREA_LOOKUP_SERVER_URL = "http://bono.metabrainz.org:8000/area-lookup/json"
 def area_lookup(area_name):

--- a/troi/tools/tests/test_area_lookup.py
+++ b/troi/tools/tests/test_area_lookup.py
@@ -1,5 +1,4 @@
 import json
-import os
 import unittest
 import unittest.mock
 

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -4,7 +4,7 @@ import os
 import traceback
 import sys
 
-from troi import Element, Artist, Release, Recording
+from troi import Element, Artist, Recording
 import troi.patch
 
 

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -98,7 +98,7 @@ class DumpElement(Element):
     def inputs():
         return []
 
-    def read(self, inputs, debug=False):
+    def read(self, inputs):
 
         for input in inputs:
             print_entity_list(input)

--- a/troi/webserver/main.py
+++ b/troi/webserver/main.py
@@ -102,7 +102,8 @@ def web_patch_handler():
                            slug=patch_name,
                            post_data=post_data)
 
-patches = troi.utils.discover_patches(PATCH_FOLDER)
+
+patches = troi.utils.discover_patches()
 for patch in patches:
     slug = patches[patch]().slug()
     app.add_url_rule('/%s' % slug, slug, web_patch_handler)

--- a/troi/webserver/main.py
+++ b/troi/webserver/main.py
@@ -1,16 +1,14 @@
-from collections import defaultdict
-import copy
-import json
 import os
 import sys
 import traceback
 import requests.exceptions
 
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request
 from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, \
-                                MethodNotAllowed, ImATeapot, ServiceUnavailable
+                                ImATeapot, ServiceUnavailable
 import troi.utils
 import troi.playlist
+from troi import PipelineError
 
 TEMPLATE_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "template")
 PATCH_FOLDER = "/app/patches"


### PR DESCRIPTION
Some warnings and errors that my code checker was throwing up in the code

* A bunch of unused imports
* Some missing imports in code flows that we never hit
* Remove debug parameter from Element.read subclasses
* Clean up some arguments in subclasses, especially in @staticmethod-annotated methods
* Remove some unused code
* Should use `is` to check None, not equal
* Use `None` as a default empty argument, [instead of mutable `{}`](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)