### PR TITLE
Add element to look up tags and genres on dataset hoster

### DIFF
--- a/troi/musicbrainz/genre_lookup.py
+++ b/troi/musicbrainz/genre_lookup.py
@@ -1,0 +1,67 @@
+import requests
+import ujson
+
+from troi import Element, Recording, PipelineError
+
+
+class GenreLookupElement(Element):
+    """
+        Look up musicbrainz tag and genres for a list of recordings recordings, based on recording mbid.
+    """
+
+    SERVER_URL = "http://bono.metabrainz.org:8000/genre-mbid-lookup/json"
+
+    def __init__(self):
+        Element.__init__(self)
+
+    @staticmethod
+    def inputs():
+        return [Recording]
+
+    @staticmethod
+    def outputs():
+        return [Recording]
+
+    def read(self, inputs):
+
+        recordings = inputs[0]
+        if not recordings:
+            return []
+
+        data = []
+        for r in recordings:
+            data.append({'[recording_mbid]': r.mbid})
+
+        r = requests.post(self.SERVER_URL, json=data)
+        if r.status_code != 200:
+            raise PipelineError("Cannot fetch recording tags from MusicBrainz: HTTP code %d" % r.status_code)
+
+        try:
+            rows = ujson.loads(r.text)
+        except ValueError as err:
+            raise PipelineError("Cannot fetch recording tags from MusicBrainz: " + str(err))
+
+        mbid_index = {}
+        for row in rows:
+            mbid_index[row['recording_mbid']] = row
+
+        output = []
+        for r in recordings:
+            try:
+                tags = mbid_index[r.mbid].get('tags', '')
+                if tags:
+                    r.musicbrainz['tags'] = tags.split(',')
+                else:
+                    r.musicbrainz['tags'] = []
+                genres = mbid_index[r.mbid].get('genres', '')
+                if genres:
+                    r.musicbrainz['genres'] = genres.split(',')
+                else:
+                    r.musicbrainz['genres'] = []
+            except KeyError:
+                self.debug("recording (%s) not found, skipping." % r.mbid)
+                continue
+
+            output.append(r)
+
+        return output

--- a/troi/musicbrainz/tests/test_genre_lookup.py
+++ b/troi/musicbrainz/tests/test_genre_lookup.py
@@ -1,0 +1,54 @@
+import json
+import unittest
+import unittest.mock
+
+import troi
+import troi.musicbrainz.genre_lookup
+
+return_json = [
+   {
+      'recording_mbid': '00440193-f84c-4e3d-b23c-a96d21c050e6',
+      'genres': 'downtempo',
+      'tags': 'downtempo'
+   },
+   {
+      'recording_mbid': '0222ff68-4590-49b7-b063-c625e0f735ed',
+      'genres': '',
+      'tags': ''
+   },
+   {
+      'recording_mbid': '1636e7a9-229d-446d-aa81-e33071b42d7a',
+      'genres': 'hip hop',
+      'tags': 'hip hop,hip-hop,hip-hop rap'
+   }
+]
+
+
+class TestGenreLookup(unittest.TestCase):
+
+    @unittest.mock.patch('requests.post')
+    def test_read(self, req):
+
+        mock = unittest.mock.MagicMock()
+        mock.status_code = 200
+        mock.text = json.dumps(return_json)
+        req.return_value = mock
+        e = troi.musicbrainz.genre_lookup.GenreLookupElement()
+
+        r = [troi.Recording(mbid='00440193-f84c-4e3d-b23c-a96d21c050e6'),
+             troi.Recording(mbid='0222ff68-4590-49b7-b063-c625e0f735ed'),
+             troi.Recording(mbid='1636e7a9-229d-446d-aa81-e33071b42d7a')]
+        entities = e.read([r])
+        req.assert_called_with(e.SERVER_URL, json=[
+            {'[recording_mbid]': '00440193-f84c-4e3d-b23c-a96d21c050e6'},
+            {'[recording_mbid]': '0222ff68-4590-49b7-b063-c625e0f735ed'},
+            {'[recording_mbid]': '1636e7a9-229d-446d-aa81-e33071b42d7a'}
+        ])
+
+        assert len(entities) == 3
+        assert entities[0].musicbrainz['tags'] == ['downtempo']
+        assert entities[0].musicbrainz['genres'] == ['downtempo']
+        assert entities[1].musicbrainz['tags'] == []
+        assert entities[1].musicbrainz['genres'] == []
+        assert entities[2].musicbrainz['tags'] == ['hip hop', 'hip-hop', 'hip-hop rap']
+        assert entities[2].musicbrainz['genres'] == ['hip hop']


### PR DESCRIPTION
I used the `Recording.musicbrainz` dictionary to store this data, because that's where it comes from.