### PR TITLE
Update AnnoyElement to match the similarity api in AB prod

### DIFF
--- a/troi/acousticbrainz/annoy.py
+++ b/troi/acousticbrainz/annoy.py
@@ -42,7 +42,8 @@ class AnnoyLookupElement(Element):
 
         url = self.SERVER_URL + self.metric
         self.debug(f"url: {url}")
-        r = requests.get(url, params={'remove_dups': 'true', 'recording_ids': [self.mbid]})
+        # recording_ids format is mbid:offset;mbid:offset
+        r = requests.get(url, params={'remove_dups': 'true', 'recording_ids': self.mbid + ":0;"})
         if r.status_code != 200:
             raise PipelineError("Cannot fetch annoy similarities from AcousticBrainz: HTTP code %d" % r.status_code)
 

--- a/troi/acousticbrainz/annoy.py
+++ b/troi/acousticbrainz/annoy.py
@@ -40,10 +40,10 @@ class AnnoyLookupElement(Element):
     def read(self, inputs):
         self.debug("read for %s/%s" % (self.metric, self.mbid))
 
-        url = self.SERVER_URL + self.metric
+        url = self.SERVER_URL + self.metric + "/"
         self.debug(f"url: {url}")
         # recording_ids format is mbid:offset;mbid:offset
-        r = requests.get(url, params={'remove_dups': 'true', 'recording_ids': self.mbid + ":0;"})
+        r = requests.get(url, params={'remove_dups': 'true', 'recording_ids': self.mbid + ":0"})
         if r.status_code != 200:
             raise PipelineError("Cannot fetch annoy similarities from AcousticBrainz: HTTP code %d" % r.status_code)
 

--- a/troi/acousticbrainz/annoy.py
+++ b/troi/acousticbrainz/annoy.py
@@ -20,7 +20,7 @@ class AnnoyLookupElement(Element):
         criteria (e.g. mfccs, gfccs, etc).
     """
 
-    SERVER_URL = "http://similarity.acousticbrainz.org/api/v1/similarity/"
+    SERVER_URL = "https://acousticbrainz.org/api/v1/similarity/"
 
     def __init__(self, metric, mbid):
         """
@@ -40,9 +40,9 @@ class AnnoyLookupElement(Element):
     def read(self, inputs):
         self.debug("read for %s/%s" % (self.metric, self.mbid))
 
-        url = self.SERVER_URL + self.metric + "/" + self.mbid
+        url = self.SERVER_URL + self.metric
         self.debug(f"url: {url}")
-        r = requests.get(url, params={'remove_dups': 'true'})
+        r = requests.get(url, params={'remove_dups': 'true', 'recording_ids': [self.mbid]})
         if r.status_code != 200:
             raise PipelineError("Cannot fetch annoy similarities from AcousticBrainz: HTTP code %d" % r.status_code)
 
@@ -52,7 +52,7 @@ class AnnoyLookupElement(Element):
             raise PipelineError("Cannot fetch annoy similarities from AcousticBrainz: Invalid JSON returned: " + str(err))
 
         entities = []
-        for row in results:
+        for row in results[self.mbid]["0"]:
             r = Recording(mbid=row['recording_mbid'], 
                           acousticbrainz={
                               'metric': self.metric,

--- a/troi/acousticbrainz/tests/test_annoy.py
+++ b/troi/acousticbrainz/tests/test_annoy.py
@@ -56,8 +56,8 @@ class TestAnnoyLookupElement(unittest.TestCase):
         e = troi.acousticbrainz.annoy.AnnoyLookupElement("mfccs", "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf")
 
         entities = e.read([[]])
-        req.assert_called_with(e.SERVER_URL + "mfccs", params={
-            "remove_dups": "true", "recording_ids": "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0;"
+        req.assert_called_with(e.SERVER_URL + "mfccs/", params={
+            "remove_dups": "true", "recording_ids": "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0"
         })
 
         assert len(entities) == 6

--- a/troi/acousticbrainz/tests/test_annoy.py
+++ b/troi/acousticbrainz/tests/test_annoy.py
@@ -57,7 +57,7 @@ class TestAnnoyLookupElement(unittest.TestCase):
 
         entities = e.read([[]])
         req.assert_called_with(e.SERVER_URL + "mfccs", params={
-            "remove_dups": "true", "recording_ids": ["8f8cc91f-0bca-4351-90d4-ef334ac0a0cf"]
+            "remove_dups": "true", "recording_ids": ["8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0;"]
         })
 
         assert len(entities) == 6

--- a/troi/acousticbrainz/tests/test_annoy.py
+++ b/troi/acousticbrainz/tests/test_annoy.py
@@ -6,38 +6,42 @@ import troi
 import troi.acousticbrainz.annoy
 from troi import PipelineError
 
-return_json = [
-  {
-    "distance": 0.00010826535435626283,
-    "offset": 0,
-    "recording_mbid": "7b3ecb51-919b-494d-8085-47e3390dd212"
-  },
-  {
-    "distance": 0.3184245228767395,
-    "offset": 0,
-    "recording_mbid": "724335d8-4ae6-4b2d-8be5-056944b8132d"
-  },
-  {
-    "distance": 0.3630277216434479,
-    "offset": 0,
-    "recording_mbid": "d4b46b96-ab56-4f99-a59e-bab590deed8f"
-  },
-  {
-    "distance": 0.3671037256717682,
-    "offset": 0,
-    "recording_mbid": "441a879f-4b8c-4d52-8a6f-e289bef2fd83"
-  },
-  {
-    "distance": 0.3676069676876068,
-    "offset": 0,
-    "recording_mbid": "b26b7d9f-dd39-4b74-89f0-a534d6bbf556"
-  },
-  {
-    "distance": 0.385963499546051,
-    "offset": 0,
-    "recording_mbid": "c1d750f3-93ea-4e0e-85f0-8baa8548c97a"
-  },
-]
+return_json = {
+    "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf": {
+        "0": [
+                {
+                    "distance": 0.00010826535435626283,
+                    "offset": 0,
+                    "recording_mbid": "7b3ecb51-919b-494d-8085-47e3390dd212"
+                },
+                {
+                    "distance": 0.3184245228767395,
+                    "offset": 0,
+                    "recording_mbid": "724335d8-4ae6-4b2d-8be5-056944b8132d"
+                },
+                {
+                    "distance": 0.3630277216434479,
+                    "offset": 0,
+                    "recording_mbid": "d4b46b96-ab56-4f99-a59e-bab590deed8f"
+                },
+                {
+                    "distance": 0.3671037256717682,
+                    "offset": 0,
+                    "recording_mbid": "441a879f-4b8c-4d52-8a6f-e289bef2fd83"
+                },
+                {
+                    "distance": 0.3676069676876068,
+                    "offset": 0,
+                    "recording_mbid": "b26b7d9f-dd39-4b74-89f0-a534d6bbf556"
+                },
+                {
+                    "distance": 0.385963499546051,
+                    "offset": 0,
+                    "recording_mbid": "c1d750f3-93ea-4e0e-85f0-8baa8548c97a"
+                },
+            ]
+    }
+}
 
 
 class TestAnnoyLookupElement(unittest.TestCase):
@@ -52,8 +56,9 @@ class TestAnnoyLookupElement(unittest.TestCase):
         e = troi.acousticbrainz.annoy.AnnoyLookupElement("mfccs", "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf")
 
         entities = e.read([[]])
-        req.assert_called_with(e.SERVER_URL + "mfccs/8f8cc91f-0bca-4351-90d4-ef334ac0a0cf",
-                               params={"remove_dups": "true"})
+        req.assert_called_with(e.SERVER_URL + "mfccs", params={
+            "remove_dups": "true", "recording_ids": ["8f8cc91f-0bca-4351-90d4-ef334ac0a0cf"]
+        })
 
         assert len(entities) == 6
         assert entities[0].acousticbrainz == {

--- a/troi/acousticbrainz/tests/test_annoy.py
+++ b/troi/acousticbrainz/tests/test_annoy.py
@@ -57,7 +57,7 @@ class TestAnnoyLookupElement(unittest.TestCase):
 
         entities = e.read([[]])
         req.assert_called_with(e.SERVER_URL + "mfccs", params={
-            "remove_dups": "true", "recording_ids": ["8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0;"]
+            "remove_dups": "true", "recording_ids": "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0;"
         })
 
         assert len(entities) == 6

--- a/troi/musicbrainz/tests/test_mbid_mapping.py
+++ b/troi/musicbrainz/tests/test_mbid_mapping.py
@@ -43,7 +43,7 @@ class TestMBIDMapping(unittest.TestCase):
         assert entities[0].name == "Trigger Hippie"
 
 
-    @unittest.mock.patch('requests.get')
+    @unittest.mock.patch('requests.post')
     def test_read_remove_unmatched(self, req):
 
         mock = unittest.mock.MagicMock()


### PR DESCRIPTION
It appears that we have changed AB's similarity API endpoint when finalizing the annoy PR. Hence, the AnnoyElement in Troi needs to be fixed up as well. Notably, the recording_ids should now be passed as a query param and the JSON returned by the endpoint looks like the example in the updated test. This should hopefully resolve #38.