### PR TITLE
Teach troi for loops

### DIFF
--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -72,7 +72,9 @@ class Element(ABC):
                 if result is None:
                     return None
 
-                if len(self.inputs()) > 0 and type(result[0]) not in self.inputs():
+                if len(self.inputs()) > 0 and \
+                    type(result[0]) not in self.inputs() and \
+                    len(self.outputs()) > 0:
                     raise RuntimeError("Element %s was expected to output %s, but actually output %s" % 
                                        (type(source).__name__, source.outputs()[0], type(result[0])))
 
@@ -254,14 +256,15 @@ class Playlist(Entity):
         and that filename is the suggested filename that this playlist should be saved as, if the user asked to 
         do that and didn't provide a different filename.
     """
-    def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None,
-                 ranking=None, year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
+    def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
+                 year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
         self.mbid = mbid
         self.recordings = recordings
         self.description = description
+        self.patch_slug = patch_slug
 
     def __str__(self):
         return "<Playlist('%s', %s, %s)>" % (self.name, self.description, self.mbid)

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -69,6 +69,9 @@ class Element(ABC):
         if self.sources:
             for source in self.sources:
                 result = source.generate()
+                if result is None:
+                    return None
+
                 if len(self.inputs()) > 0 and type(result[0]) not in self.inputs():
                     raise RuntimeError("Element %s was expected to output %s, but actually output %s" % 
                                        (type(source).__name__, source.outputs()[0], type(result[0])))
@@ -76,6 +79,8 @@ class Element(ABC):
                 source_lists.append(result)
 
         items = self.read(source_lists)
+        if items is None:
+            return None
 
         if len(items) > 0 and type(items[0]) == Playlist:
             print("  %-50s %d items" % (type(self).__name__[:49], len(items[0].recordings or [])))
@@ -272,13 +277,13 @@ class User(Entity):
     """
         The class that represents a ListenBrainz user.
     """
-    def __init__(self, user_name=None, user_id=None)
+    def __init__(self, user_name=None, user_id=None):
         Entity.__init__(self)
         self.user_name = user_name
         self.user_id = user_id
 
     def __str__(self):
-        return "<User('%s', %d)>" % (self.user_name, self.user_id)
+        return "<User('%s', %d)>" % (self.user_name, self.user_id or -1)
 
 
 

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -257,7 +257,7 @@ class Playlist(Entity):
         do that and didn't provide a different filename.
     """
     def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
-                 year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None):
+                 year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
@@ -265,6 +265,7 @@ class Playlist(Entity):
         self.recordings = recordings
         self.description = description
         self.patch_slug = patch_slug
+        self.user_name = user_name
 
     def __str__(self):
         return "<Playlist('%s', %s, %s)>" % (self.name, self.description, self.mbid)

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -74,7 +74,7 @@ class Element(ABC):
 
                 if len(self.inputs()) > 0 and \
                     type(result[0]) not in self.inputs() and \
-                    len(self.outputs()) > 0:
+                    len(source.outputs()) > 0:
                     raise RuntimeError("Element %s was expected to output %s, but actually output %s" % 
                                        (type(source).__name__, source.outputs()[0], type(result[0])))
 

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -268,6 +268,19 @@ class Playlist(Entity):
         random.shuffle(self.recordings)
 
 
+class User(Entity):
+    """
+        The class that represents a ListenBrainz user.
+    """
+    def __init__(self, user_name=None, user_id=None)
+        Entity.__init__(self)
+        self.user_name = user_name
+        self.user_id = user_id
+
+    def __str__(self):
+        return "<User('%s', %d)>" % (self.user_name, self.user_id)
+
+
 
 class PipelineError(RuntimeError):
     """

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -73,7 +73,7 @@ class Element(ABC):
                     return None
 
                 if len(self.inputs()) > 0 and \
-                    type(result[0]) not in self.inputs() and \
+                    len(result) > 0 and type(result[0]) not in self.inputs() and \
                     len(source.outputs()) > 0:
                     raise RuntimeError("Element %s was expected to output %s, but actually output %s" % 
                                        (type(source).__name__, source.outputs()[0], type(result[0])))

--- a/troi/cli.py
+++ b/troi/cli.py
@@ -22,7 +22,7 @@ def cli():
 @click.option('--print', '-p', 'echo', required=False, is_flag=True)
 @click.option('--save', '-s', required=False, is_flag=True)
 @click.option('--token', '-t', required=False, type=click.UUID)
-@click.option('--upload', '-u', required=False, type=click.UUID)
+@click.option('--upload', '-u', required=False, is_flag=True)
 @click.option('--created-for', '-c', required=False)
 @click.option('--name', '-n', required=False)
 @click.option('--desc', '-d', required=False)

--- a/troi/cli.py
+++ b/troi/cli.py
@@ -92,14 +92,14 @@ def playlist(patch, debug, echo, save, token, upload, args, created_for, name, d
         print("In order to upload a playlist, you must provide an auth token. Use option --token.")
         sys.exit(2)
 
-    if result is not None and token and upload:
-        for url, _ in playlist.submit(token, created_for):
-            print("Submitted playlist: %s" % url)
-
     if min_recordings is not None and \
         (len(playlist.playlists) == 0 or len(playlist.playlists[0].recordings) < min_recordings):
         print("Playlist does not have at least %d recordings, stopping." % min_recordings)
         sys.exit(0)
+
+    if result is not None and token and upload:
+        for url, _ in playlist.submit(token, created_for):
+            print("Submitted playlist: %s" % url)
 
     if result is not None and save:
         playlist.save()

--- a/troi/cli.py
+++ b/troi/cli.py
@@ -52,8 +52,17 @@ def playlist(patch, debug, echo, save, token, args, created_for, name, desc):
 
     context = patch.parse_args.make_context(patchname, list(args))
     pipelineargs = context.forward(patch.parse_args)
-    pipeline = patch.create(pipelineargs)
 
+    patch_args = {
+        "echo": echo,
+        "save": save,
+        "token": token,
+        "created_for": created_for, 
+        "name": name,
+        "desc": desc
+    }
+
+    pipeline = patch.create(pipelineargs, patch_args)
     try:
         playlist = troi.playlist.PlaylistElement()
         playlist.set_sources(pipeline)
@@ -70,7 +79,7 @@ def playlist(patch, debug, echo, save, token, args, created_for, name, desc):
         print("Failed to generate playlist: %s" % err, file=sys.stderr)
         sys.exit(2)
 
-    if token:
+    if result is not None and token:
         for url, _ in playlist.submit(token, created_for):
             print("Submitted playlist: %s" % url)
 

--- a/troi/filters.py
+++ b/troi/filters.py
@@ -232,7 +232,7 @@ class EmptyRecordingFilterElement(troi.Element):
         recordings = inputs[0]
         output = []
         for rec in recordings:
-            if rec.name is None or (rec.artist and rec.artist.name is None):
+            if rec.name is None or (rec.artist and rec.artist.name is None) or rec.mbid is None:
                 if debug:
                     print(f"recording {rec.mbid} has no metadata, filtering")
             else:

--- a/troi/listenbrainz/dataset_fetcher.py
+++ b/troi/listenbrainz/dataset_fetcher.py
@@ -40,7 +40,26 @@ class DataSetFetcherElement(Element):
 
             r = Recording(mbid=row['recording_mbid']) 
             if 'artist_credit_name' in row:
-                r.artist = Artist(name=row['artist_credit_name'])
+                if 'artist_credit_id' in row:
+                    r.artist.artist_credit_id = row['artist_credit_id']
+
+            artist = None
+            if 'artist_credit_name' in row:
+                artist = Artist(name=row['artist_credit_name'])
+
+            if 'artist_credit_id' in row:
+                if artist is None:
+                    artist = Artist(artist_credit_id=row['artist_credit_id'])
+                else:
+                    artist.artist_credit_id = row['artist_credit_id']
+
+            if 'artist_mbids' in row:
+                if artist is None:
+                    artist = Artist(mbids=row['artist_mbids'])
+                else:
+                    artist.mbids = row['artist_mbids']
+
+            r.artist = artist
 
             if 'recording_name' in row:
                 r.name = row['recording_name']

--- a/troi/listenbrainz/stats.py
+++ b/troi/listenbrainz/stats.py
@@ -1,5 +1,6 @@
 from troi import Element, Artist, Release, Recording
 import pylistenbrainz
+import pylistenbrainz.errors
 
 
 class UserArtistsElement(Element):
@@ -80,7 +81,15 @@ class UserRecordingElement(Element):
 
     def read(self, inputs = []):
         recording_list = []
-        recordings = self.client.get_user_recordings(self.user_name, self.count, self.offset, self.time_range)
+        try:
+            recordings = self.client.get_user_recordings(self.user_name, self.count, self.offset, self.time_range)
+        except pylistenbrainz.errors.ListenBrainzAPIException as err:
+            print("Cannot fetch recording stats for user %s" % self.user_name)
+            return []
+
+        if recordings is None or "recordings" not in recordings['payload']:
+            return []
+
         for r in recordings['payload']['recordings']:
             artist = Artist(r['artist_name'], mbids=r['artist_mbids'], msid=r['artist_msid'])
             release = Release(r['release_name'], mbid=r['release_mbid'], msid=r['release_msid'])

--- a/troi/listenbrainz/stats.py
+++ b/troi/listenbrainz/stats.py
@@ -7,9 +7,11 @@ class UserArtistsElement(Element):
         Fetch artist statistics from ListenBrainz
     '''
 
-    def __init__(self, user_name, count=25, offset=0, time_range='all_time'):
+    def __init__(self, user_name, count=25, offset=0, time_range='all_time', auth_token=None):
         super().__init__()
         self.client = pylistenbrainz.ListenBrainz()
+        if auth_token:
+            self.client.set_auth_token(auth_token)
         self.user_name = user_name
         self.count = count
         self.offset = offset
@@ -33,9 +35,11 @@ class UserReleasesElement(Element):
         Fetch release statistics from ListenBrainz
     '''
 
-    def __init__(self, user_name, count=25, offset=0, time_range='all_time'):
+    def __init__(self, user_name, count=25, offset=0, time_range='all_time', auth_token=None):
         super().__init__()
         self.client = pylistenbrainz.ListenBrainz()
+        if auth_token:
+            self.client.set_auth_token(auth_token)
         self.user_name = user_name
         self.count = count
         self.offset = offset
@@ -61,9 +65,11 @@ class UserRecordingElement(Element):
         Fetch recording statistics from ListenBrainz
     '''
 
-    def __init__(self, user_name, count=25, offset=0, time_range='all_time'):
+    def __init__(self, user_name, count=25, offset=0, time_range='all_time', auth_token=None):
         super().__init__()
         self.client = pylistenbrainz.ListenBrainz()
+        if auth_token:
+            self.client.set_auth_token(auth_token)
         self.user_name = user_name
         self.count = count
         self.offset = offset

--- a/troi/listenbrainz/user.py
+++ b/troi/listenbrainz/user.py
@@ -1,0 +1,22 @@
+from troi import Element, User
+
+
+class UserListElement(Element):
+    '''
+        This element is used to pass a provided list of users into the pipeline.
+    '''
+
+    def __init__(self, user_list):
+        super().__init__()
+        self.user_list = user_list
+
+    @staticmethod
+    def inputs():
+        return []
+
+    @staticmethod
+    def outputs():
+        return [User]
+
+    def read(self, inputs):
+        return [ User(user_name=user_name) for user_name in user_list ]

--- a/troi/listenbrainz/user.py
+++ b/troi/listenbrainz/user.py
@@ -19,4 +19,4 @@ class UserListElement(Element):
         return [User]
 
     def read(self, inputs):
-        return [ User(user_name=user_name) for user_name in user_list ]
+        return [ User(user_name=user_name) for user_name in self.user_list ]

--- a/troi/listenbrainz/yim_user.py
+++ b/troi/listenbrainz/yim_user.py
@@ -1,0 +1,38 @@
+import psycopg2
+from psycopg2.errors import OperationalError
+import psycopg2.extras
+
+from troi import Element, User
+
+LB_CONNECT_URI = "postgresql://listenbrainz:listenbrainz@localhost:65400/listenbrainz"
+
+
+class YIMUserListElement(Element):
+    '''
+        This element is used to fetch a list of users who need to have playlists generated for them.
+    '''
+
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def inputs():
+        return []
+
+    @staticmethod
+    def outputs():
+        return [User]
+
+    def read(self, inputs):
+
+        with psycopg2.connect(LB_CONNECT_URI) as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+
+                query = """SELECT "user".musicbrainz_id AS user_name
+                             FROM "user"
+                             JOIN statistics.year_in_music yim
+                               ON "user".id = yim.user_id
+                            WHERE yim.data->'playlists'->>'slug' is NULL"""
+                curs.execute(query)
+
+                return [ User(user_name=row["user_name"]) for row in curs.fetchall()]

--- a/troi/listenbrainz/yim_user.py
+++ b/troi/listenbrainz/yim_user.py
@@ -4,7 +4,7 @@ import psycopg2.extras
 
 from troi import Element, User
 
-LB_CONNECT_URI = "postgresql://listenbrainz:listenbrainz@localhost:65400/listenbrainz"
+MB_CONNECT_URI = "postgresql://musicbrainz:musicbrainz@localhost:25432/musicbrainz_db"
 
 
 class YIMUserListElement(Element):
@@ -25,15 +25,13 @@ class YIMUserListElement(Element):
 
     def read(self, inputs):
 
-        with psycopg2.connect(LB_CONNECT_URI) as conn:
+        with psycopg2.connect(MB_CONNECT_URI) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
 
-                query = """SELECT "user".musicbrainz_id AS user_name
-                             FROM "user"
-                             JOIN statistics.year_in_music yim
-                               ON "user".id = yim.user_id
-                            WHERE yim.data->'playlists'->>'slug' is NULL
-                            LIMIT 100"""
+                query = """SELECT DISTINCT user_name
+                             FROM mapping.tracks_of_the_year
+                         ORDER BY user_name"""
+
                 curs.execute(query)
 
                 return [ User(user_name=row["user_name"]) for row in curs.fetchall()]

--- a/troi/listenbrainz/yim_user.py
+++ b/troi/listenbrainz/yim_user.py
@@ -32,7 +32,8 @@ class YIMUserListElement(Element):
                              FROM "user"
                              JOIN statistics.year_in_music yim
                                ON "user".id = yim.user_id
-                            WHERE yim.data->'playlists'->>'slug' is NULL"""
+                            WHERE yim.data->'playlists'->>'slug' is NULL
+                            LIMIT 100"""
                 curs.execute(query)
 
                 return [ User(user_name=row["user_name"]) for row in curs.fetchall()]

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -49,6 +49,7 @@ class ForLoopElement(troi.Element):
                 args = copy(self.pipeline_args)
                 args["user_name"] = user.user_name
                 pipeline = patch.create(args, self.patch_args)
+                self.patch_args["created_for"] = user.user_name
 
                 try:
                     print("generate %s for %s" % (patch_slug, user.user_name))
@@ -64,14 +65,18 @@ class ForLoopElement(troi.Element):
                     if self.patch_args["echo"]:
                         playlist.print()
 
+                    metadata = { "source_patch": patch_slug }
                     if self.patch_args["upload"]:
                         if not self.patch_args["token"] or self.patch_args["token"] == "":
                             raise PipelineError("In order to upload a playlist an auth token must be provided. Use --token")
 
                         if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
-                            playlist.submit(self.patch_args["token"], self.patch_args["created_for"])
+                            playlist.submit(self.patch_args["token"],
+                                            self.patch_args["created_for"],
+                                            algorithm_metadata=metadata)
                         else:
-                            playlist.submit(self.patch_args["token"])
+                            playlist.submit(self.patch_args["token"],
+                                            algorithm_metadata=metadata)
 
                     outputs.append(playlist.playlists[0])
                     print()

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -70,13 +70,17 @@ class ForLoopElement(troi.Element):
                         if not self.patch_args["token"] or self.patch_args["token"] == "":
                             raise PipelineError("In order to upload a playlist an auth token must be provided. Use --token")
 
-                        if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
-                            playlist.submit(self.patch_args["token"],
-                                            self.patch_args["created_for"],
-                                            algorithm_metadata=metadata)
-                        else:
-                            playlist.submit(self.patch_args["token"],
-                                            algorithm_metadata=metadata)
+                        try:
+                            if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
+                                playlist.submit(self.patch_args["token"],
+                                                self.patch_args["created_for"],
+                                                algorithm_metadata=metadata)
+                            else:
+                                playlist.submit(self.patch_args["token"],
+                                                algorithm_metadata=metadata)
+                        except troi.PipelineError as err:
+                            print("Failed to submit playlist: %s, continuing..." % err, file=sys.stderr)
+                            next
 
                     outputs.append(playlist.playlists[0])
                     print()

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -1,0 +1,75 @@
+from collections import defaultdict
+from copy import copy
+import sys
+
+import troi
+from troi import PipelineError, Element, User
+from troi.utils import discover_patches
+
+
+class ForLoopElement(troi.Element):
+    '''
+        An element that receives items from a pipeline and for each item in the pipeline it
+        instantiates a new patch and executes that patch. A normal use case might include
+        taking a list of users and running the specified patch for each user.
+
+        As of right now, only User objects can be processed with this element.
+
+        Arguments:
+            patch_slug - the slug of the patch to run inside the for loop
+            pipeline_args - the arguments passed to top-level pipeline, so that they
+                            apply to dynamically created pipelines inside the for loop
+    '''
+
+    def __init__(self, patch_slugs, pipeline_args, patch_args=None):
+        super().__init__()
+        self.patch_slugs = patch_slugs
+        self.pipeline_args = pipeline_args
+        self.patch_args = patch_args
+
+    @staticmethod
+    def inputs():
+        return [User]
+
+    @staticmethod
+    def outputs():
+        return []
+
+    def read(self, inputs):
+
+        patches = discover_patches()
+
+        outputs = []
+        for patch_slug in self.patch_slugs:
+            if not patch_slug in patches:
+                raise PipelineError("ForLoop: Cannot load patch '%s'" % patch_slug)
+
+            patch = patches[patch_slug](False)
+            for user in inputs[0]:
+                args = copy(self.pipeline_args)
+                args["user_name"] = user.user_name
+                pipeline = patch.create(args, self.patch_args)
+
+                try:
+                    print("generate %s for %s" % (patch_slug, user.user_name))
+                    playlist = troi.playlist.PlaylistElement()
+                    playlist.set_sources(pipeline)
+                    playlist.generate()
+
+                    if self.patch_args["echo"]:
+                        playlist.print()
+
+                    if self.patch_args["token"] and self.patch_args["token"] != "":
+                        if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
+                            playlist.submit(self.patch_args["token"], self.patch_args["created_for"])
+                        else:
+                            playlist.submit(self.patch_args["token"])
+
+                    outputs.append(playlist.playlists[0])
+                    print()
+                except troi.PipelineError as err:
+                    print("Failed to generate playlist: %s" % err, file=sys.stderr)
+                    raise
+
+        # Return None if you want to stop processing this pipeline
+        return outputs

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -56,6 +56,10 @@ class ForLoopElement(troi.Element):
                     playlist.set_sources(pipeline)
                     playlist.generate()
 
+                    if len(playlist.playlists[0].recordings) < self.patch_args["min_recordings"]:
+                        print("Playlist does not have at least %d recordings, not submitting.\n" % self.patch_args["min_recordings"])
+                        continue
+
                     if self.patch_args["echo"]:
                         playlist.print()
 

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -56,14 +56,18 @@ class ForLoopElement(troi.Element):
                     playlist.set_sources(pipeline)
                     playlist.generate()
 
-                    if len(playlist.playlists[0].recordings) < self.patch_args["min_recordings"]:
+                    if self.patch_args["min_recordings"] is not None and \
+                        len(playlist.playlists[0].recordings) < self.patch_args["min_recordings"]:
                         print("Playlist does not have at least %d recordings, not submitting.\n" % self.patch_args["min_recordings"])
                         continue
 
                     if self.patch_args["echo"]:
                         playlist.print()
 
-                    if self.patch_args["token"] and self.patch_args["token"] != "":
+                    if self.patch_args["upload"]:
+                        if not self.patch_args["token"] or self.patch_args["token"] == "":
+                            raise PipelineError("In order to upload a playlist an auth token must be provided. Use --token")
+
                         if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
                             playlist.submit(self.patch_args["token"], self.patch_args["created_for"])
                         else:

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -80,7 +80,7 @@ class ForLoopElement(troi.Element):
                                                 algorithm_metadata=metadata)
                         except troi.PipelineError as err:
                             print("Failed to submit playlist: %s, continuing..." % err, file=sys.stderr)
-                            next
+                            continue
 
                     outputs.append(playlist.playlists[0])
                     print()

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -66,9 +66,13 @@ class Patch(ABC):
         return None
 
     @abstractmethod
-    def create(self, input_args):
+    def create(self, input_args, patch_args):
         '''
-            The function creates the data pipeline and then returns it.
+            The function creates the data pipeline and then returns it. 
+
+            Params:
+               input_args: the passed arguments to the pipeline
+               patch_args: the arguments passed to the topmost patch.
         '''
 
         return None

--- a/troi/patches/ab_similar_recordings.py
+++ b/troi/patches/ab_similar_recordings.py
@@ -39,7 +39,7 @@ class ABSimilarRecordingsPatch(troi.patch.Patch):
     def description():
         return "Find acoustically similar recordings from AcousticBrainz"
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         recording_id = inputs['recording_id']
         similarity_type = inputs['similarity_type']
 
@@ -51,7 +51,7 @@ class ABSimilarRecordingsPatch(troi.patch.Patch):
         dedup_filter = troi.filters.DuplicateRecordingArtistCreditFilterElement()
         dedup_filter.set_sources(r_lookup)
 
-        pl_maker = troi.playlist.PlaylistMakerElement("Annoy test playlist", "Annoy test playlist", 50)
+        pl_maker = troi.playlist.PlaylistMakerElement("Annoy test playlist", "Annoy test playlist", 50, patch_slug=self.slug())
         pl_maker.set_sources(dedup_filter)
 
         return pl_maker

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -49,7 +49,7 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
     def description():
         return "Generate a list of random recordings from a given area."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         area_name = inputs['area']
         start_year = inputs['start_year']
         end_year = inputs['end_year']

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -85,7 +85,7 @@ class DailyJamsPatch(troi.patch.Patch):
     def description():
         return "Generate a daily playlist from the ListenBrainz recommended recordings. Day 1 = Monday, Day 2  = Tuesday ..."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         user_name = inputs['user_name']
         type = inputs['type']
         day = inputs['day']

--- a/troi/patches/patch_runner.py
+++ b/troi/patches/patch_runner.py
@@ -1,0 +1,66 @@
+import click
+
+import troi
+from troi import Element, Artist, Recording, Playlist, PipelineError
+from troi.listenbrainz.user import UserListElement
+from troi.loops import ForLoopElement
+
+
+@click.group()
+def cli():
+    pass
+
+
+class PatchRunnerPatch(troi.patch.Patch):
+    """
+        Run a patch for a list of users.
+    """
+
+
+    def __init__(self, debug):
+        troi.patch.Patch.__init__(self, debug)
+
+    @staticmethod
+    @cli.command(no_args_is_help=True)
+    @click.argument('patch_slug')
+    @click.argument('user_names', nargs=-1)
+    def parse_args(**kwargs):
+        """
+        Run a patch for a number of users.
+
+        \b
+        PATCH_SLUG: The slug of the patch to run.
+        USER_NAMES: The list of ListenBrainz user names to run the patch for.
+        """
+
+        return kwargs
+
+    @staticmethod
+    def inputs():
+        return [
+                   { "type": str, "name": "patch_slug", "desc": "Troi patch name to execute", "optional": False },
+                   { "type": list, "name": "user_names", "desc": "ListenBrainz user names", "optional": False }
+               ]
+
+    @staticmethod
+    def outputs():
+        return []
+
+    @staticmethod
+    def slug():
+        return "patch-runner"
+
+    @staticmethod
+    def description():
+        return "Run a given patch for a given list users."
+
+    def create(self, inputs):
+        patch_slug = inputs["patch_slug"]
+        user_names = inputs["user_names"]
+
+        u = UserListElement(user_names)
+        
+        for_loop = ForLoopElement(patch_slug)
+        for_loop.set_sources(u)
+
+        return for_loop

--- a/troi/patches/patch_runner.py
+++ b/troi/patches/patch_runner.py
@@ -23,19 +23,17 @@ class PlaylistMultiplexerElement(Element):
 
     @staticmethod
     def inputs():
-        return []
+        return [Playlist]
 
     @staticmethod
     def outputs():
-        return []
+        return [[Playlist]]
 
     def read(self, inputs):
-        outputs = []
-        for input in inputs:
-            for entity in input:
-                outputs.append(entity)
 
-        return outputs
+        ic(inputs)
+
+        return [[ playlist for playlist in inputs ]]
 
 
 class YIMSubmitterElement(Element):
@@ -48,17 +46,19 @@ class YIMSubmitterElement(Element):
 
     @staticmethod
     def inputs():
-        return [[Playlist]]
+        return [Playlist]
 
     @staticmethod
     def outputs():
         return []
 
     def read(self, inputs):
+        ic(inputs)
 
-        for input in inputs:
-            for nested in input:
-                print(nested.playlists[0].patch_slug, nested.playlists[0].user_name)
+        print("YIMSubmitter:")
+        for playlist in inputs[0]:
+            print("  ", playlist.patch_slug, playlist.user_name)
+        print("")
 
         return None
 
@@ -119,10 +119,10 @@ class YIMRunnerPatch(troi.patch.Patch):
         for_loop = ForLoopElement(patch_slugs, inputs, patch_args)
         for_loop.set_sources(u)
 
-        m = PlaylistMultiplexerElement()
-        m.set_sources(for_loop)
+#        m = PlaylistMultiplexerElement()
+#        m.set_sources(for_loop)
 
         y = YIMSubmitterElement()
-        y.set_sources(m)
+        y.set_sources(for_loop)
 
         return y

--- a/troi/patches/patch_runner.py
+++ b/troi/patches/patch_runner.py
@@ -58,12 +58,12 @@ class YIMSubmitterElement(Element):
 
         for input in inputs:
             for nested in input:
-                print(nested.playlists[0].patch_slug)
+                print(nested.playlists[0].patch_slug, nested.playlists[0].user_name)
 
         return None
 
 
-class PatchRunnerPatch(troi.patch.Patch):
+class YIMRunnerPatch(troi.patch.Patch):
     """
         Run a patch for a list of users.
     """

--- a/troi/patches/playlist_from_mbids.py
+++ b/troi/patches/playlist_from_mbids.py
@@ -53,14 +53,14 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
     def description():
         return "Generate a playlist from a list of MBIDSs"
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
 
         source = MBIDReaderElement(inputs['file_name'])
 
         rec_lookup = RecordingLookupElement()
         rec_lookup.set_sources(source)
 
-        pl_maker = PlaylistMakerElement("Playlist made from MBIDs", "")
+        pl_maker = PlaylistMakerElement("Playlist made from MBIDs", "", patch_slug=self.slug())
         pl_maker.set_sources(rec_lookup)
 
         return pl_maker

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -87,7 +87,8 @@ class TopDiscoveries(troi.patch.Patch):
         year = datetime.now().year
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
                                                       self.DESC % (inputs['user_name'], year, year, year),
-                                                      patch_slug=self.slug())
+                                                      patch_slug=self.slug(),
+                                                      user_name=inputs['user_name'])
         pl_maker.set_sources(y_lookup)
 
         shaper = PlaylistRedundancyReducerElement()

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -77,7 +77,7 @@ class TopDiscoveries(troi.patch.Patch):
     def description():
         return "Generate a top discoveries playlist for a user."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         recs = DataSetFetcherElement(server_url="https://bono.metabrainz.org/top-discoveries/json",
                                      json_post_data=[{ 'user_name': inputs['user_name'] }])
 
@@ -86,7 +86,8 @@ class TopDiscoveries(troi.patch.Patch):
 
         year = datetime.now().year
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
-                                                      self.DESC % (inputs['user_name'], year, year, year))
+                                                      self.DESC % (inputs['user_name'], year, year, year),
+                                                      patch_slug=self.slug())
         pl_maker.set_sources(y_lookup)
 
         shaper = PlaylistRedundancyReducerElement()

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -26,22 +26,15 @@ class TopDiscoveries(troi.patch.Patch):
 
     NAME = "Top discoveries of %d for %s"
     DESC = """<p>
-              We generated this playlist from your <a href="https://listenbrainz.org/user/%s/reports?range=year">
-              listening statistics for %d</a>. We started with all the recordings that you first listened to in
-              %d and then selected the recordings that you listened to more than once. If we found recordings 
-              from more than 15 artists, we selected at most 2 recordings from each artist to make this playlist.
-              If we found 15 or fewer artists, we picked all the recordings. Finally, we returned at most 30 
-              recordings and ordered them by how many times you listened to them in %d.
+              This playlist highlights tracks that user %s first listened to more than once in %d.
+              </p>
+              <p>
+              We generated this playlist from your listens and chose all the recordings that you first
+              listened to this year and then selected the recordings that you listened to more than once.
               </p>
               <p>
               Double click on any recording to start playing it -- we'll do our best to find a matching recording
               to play. If you have Spotify, we recommend connecting your account for a better playback experience.
-              </p>
-              <p>
-              Please keep in mind that this is our first attempt at making playlists for our users. Our processes
-              are not fully debugged and you may find that things are not perfect. So, if this playlist isn't
-              very accurate, we apologize -- we'll continue to make them better. (e.g. some recordings may be missing
-              from this list because we were not able to find a match for it in MusicBrainz.)
               </p>
            """
 
@@ -86,7 +79,7 @@ class TopDiscoveries(troi.patch.Patch):
 
         year = datetime.now().year
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
-                                                      self.DESC % (inputs['user_name'], year, year, year),
+                                                      self.DESC % (inputs['user_name'], year),
                                                       patch_slug=self.slug(),
                                                       user_name=inputs['user_name'])
         pl_maker.set_sources(y_lookup)

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -24,17 +24,26 @@ class TopDiscoveries(troi.patch.Patch):
         See below for description
     """
 
-    NAME = "Top discoveries of %d for %s"
+    NAME = "Top Discoveries of %d for %s"
     DESC = """<p>
-              This playlist highlights tracks that user %s first listened to more than once in %d.
+              This playlist highlights tracks that %s first listened to in %d and listened to more than once.
               </p>
               <p>
-              We generated this playlist from your listens and chose all the recordings that you first
-              listened to this year and then selected the recordings that you listened to more than once.
+              We generated this playlist from %s's listens and chose all the recordings
+              that they first listened to this year and they listened to more than once. We removed
+              recordings from duplicate artists so that no artist (or an artist in a collaboration) appears
+              more than twice in this playlist. Finally we randomized the order of the recordings so that
+              two of the same artists hopefully won't appear in a row.
               </p>
               <p>
-              Double click on any recording to start playing it -- we'll do our best to find a matching recording
-              to play. If you have Spotify, we recommend connecting your account for a better playback experience.
+              Please remember that ListenBrainz may not know about all the times this user listened to a recording
+              before they started sharing their listening history with us, so we apologize if recordings appear that
+              this user listened to in the past. Also, we have attempted to match all of the listens to MusicBrainz
+              IDs in order for them to be included in this playlist, but we may not have been able to match them all,
+              so some recordings may be missing from this list.
+              </p>
+              <p>
+              This is a review playlist that we hope will give insights into the listening habits of the year.
               </p>
            """
 
@@ -79,7 +88,7 @@ class TopDiscoveries(troi.patch.Patch):
 
         year = datetime.now().year
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
-                                                      self.DESC % (inputs['user_name'], year),
+                                                      self.DESC % (inputs['user_name'], year, inputs['user_name']),
                                                       patch_slug=self.slug(),
                                                       user_name=inputs['user_name'])
         pl_maker.set_sources(y_lookup)

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -31,9 +31,10 @@ class TopDiscoveries(troi.patch.Patch):
               <p>
               We generated this playlist from %s's listens and chose all the recordings
               that they first listened to this year and they listened to more than once. We removed
-              recordings from duplicate artists so that no artist (or an artist in a collaboration) appears
-              more than twice in this playlist. Finally we randomized the order of the recordings so that
-              two of the same artists hopefully won't appear in a row.
+              recordings from duplicate artists so that ideally no artist (or an artist in a collaboration) appears
+              more than twice in this playlist, although that may not always be possible. 
+              Finally we randomized the order of the recordings so that two of the same artists hopefully
+              won't appear in a row.
               </p>
               <p>
               Please remember that ListenBrainz may not know about all the times this user listened to a recording

--- a/troi/patches/top_missed_recordings_for_year.py
+++ b/troi/patches/top_missed_recordings_for_year.py
@@ -72,7 +72,8 @@ class TopMissedTracksPatch(troi.patch.Patch):
         year = datetime.now().year
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % inputs['user_name'],
                                                       self.DESC,
-                                                      patch_slug=self.slug())
+                                                      patch_slug=self.slug(),
+                                                      user_name=inputs['user_name'])
         pl_maker.set_sources(source)
 
         reducer = PlaylistRedundancyReducerElement(max_num_recordings=self.max_num_recordings)

--- a/troi/patches/top_missed_recordings_for_year.py
+++ b/troi/patches/top_missed_recordings_for_year.py
@@ -21,14 +21,27 @@ class TopMissedTracksPatch(troi.patch.Patch):
         See below for description
     """
 
-    NAME = "Top Missed recordings for %s"
+    NAME = "Top Missed Recordings of %d for %s"
     DESC = """<p>
-              This playlist is made from tracks that your most similar users listened to this year, but that
-              you didn't listen to this year.
+              This playlist is made from recordings that %s's most similar users listened to this year, but that
+              %s didn't listen to this year.
               </p>
               <p>
-              Double click on any recording to start playing it -- we'll do our best to find a matching recording
-              to play. If you have Spotify, we recommend connecting your account for a better playback experience.
+              We determined the top 3 most similar users to %s and selected all of the recordings
+              they listened to this year. We then removed all of the recordings that %s listened to from
+              this list of recordings, leaving only those that they didn't listen to. Finally we
+              randomized the order of the recordings so that two of the same artists hopefully won't appear
+              in a row.
+              </p>
+              <p>
+              We have attempted to match all of the listens to MusicBrainz
+              IDs in order for them to be included in this playlist, but we may not have been able to match them all,
+              so some recordings may be missing from this list.
+              </p>
+              <p>
+              This is a discovery playlist that will hopefully introduce the user to some new recordings
+              that other similar users love. Because this is a discovery playlist, it may require
+              more active listening since it may contain tracks that are not fully to the taste of the user.
               </p>
            """
 
@@ -70,8 +83,8 @@ class TopMissedTracksPatch(troi.patch.Patch):
                                        json_post_data=[{ 'user_name': inputs['user_name'] }])
 
         year = datetime.now().year
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % inputs['user_name'],
-                                                      self.DESC,
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
+                                                      self.DESC % (inputs['user_name'], inputs['user_name'], inputs['user_name'], inputs['user_name']),
                                                       patch_slug=self.slug(),
                                                       user_name=inputs['user_name'])
         pl_maker.set_sources(source)

--- a/troi/patches/top_missed_recordings_for_year.py
+++ b/troi/patches/top_missed_recordings_for_year.py
@@ -29,7 +29,9 @@ class TopMissedTracksPatch(troi.patch.Patch):
               <p>
               We determined the top 3 most similar users to %s and selected all of the recordings
               they listened to this year. We then removed all of the recordings that %s listened to from
-              this list of recordings, leaving only those that they didn't listen to. Finally we
+              this list of recordings, leaving only those that they didn't listen to. We removed recordings from
+              duplicate artists so that ideally no artist (or an artist in a collaboration) appears
+              more than twice in this playlist, although that may not always be possible. Finally we
               randomized the order of the recordings so that two of the same artists hopefully won't appear
               in a row.
               </p>

--- a/troi/patches/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/patches/top_new_recordings_you_listened_to_for_year.py
@@ -23,9 +23,25 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
     """
         See below for description
     """
-    NAME = "Tracks released in %d that you've listened to."
-    DESC = """Tracks that were released in %d that you've listened to. (Yes, we finish
-              sentences with prepositions here.)"""
+    NAME = "Top New Releases in %d for %s"
+    DESC = """<p>
+              This playlist highlights recordings released in %d that %s listened to the most.
+              </p>
+              <p>
+              We generated this playlist from the user's listens and chose all the recordings
+              that were released this year and that the user listened to often. We removed
+              recordings from duplicate artists so that no artist (or an artist in a collaboration) appears
+              more than twice in this playlist. Finally we randomized the order of the recordings so that
+              two of the same artists hopefully won't appear in a row.
+              </p>
+              <p>
+              We have attempted to match all of the listens to MusicBrainz
+              IDs in order for them to be included in this playlist, but we may not have been able to match them all,
+              so some recordings may be missing from this list.
+              </p>
+              <p>
+              This is a review playlist that we hope will give insights the music released during the year.
+              </p>"""
 
     def __init__(self, debug=False, max_num_recordings=50):
         troi.patch.Patch.__init__(self, debug)
@@ -69,8 +85,8 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         y_lookup.set_sources(recs)
 
         year = datetime.now().year
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % year,
-                                                      self.DESC % year,
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, inputs['user_name']),
+                                                      self.DESC % (year, inputs['user_name']),
                                                       patch_slug=self.slug(),
                                                       user_name=inputs['user_name'])
         pl_maker.set_sources(recs)

--- a/troi/patches/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/patches/top_new_recordings_you_listened_to_for_year.py
@@ -29,10 +29,10 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
               </p>
               <p>
               We generated this playlist from the user's listens and chose all the recordings
-              that were released this year and that the user listened to often. We removed
-              recordings from duplicate artists so that no artist (or an artist in a collaboration) appears
-              more than twice in this playlist. Finally we randomized the order of the recordings so that
-              two of the same artists hopefully won't appear in a row.
+              that were released this year and that the user listened to often. We removed recordings
+              from duplicate artists so that ideally no artist (or an artist in a collaboration) appears
+              more than twice in this playlist, although that may not always be possible. Finally we randomized
+              the order of the recordings so that two of the same artists hopefully won't appear in a row.
               </p>
               <p>
               We have attempted to match all of the listens to MusicBrainz

--- a/troi/patches/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/patches/top_new_recordings_you_listened_to_for_year.py
@@ -69,7 +69,10 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         y_lookup.set_sources(recs)
 
         year = datetime.now().year
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % year, self.DESC % year, patch_slug=self.slug())
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % year,
+                                                      self.DESC % year,
+                                                      patch_slug=self.slug(),
+                                                      user_name=inputs['user_name'])
         pl_maker.set_sources(recs)
 
         shaper = PlaylistRedundancyReducerElement()

--- a/troi/patches/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/patches/top_new_recordings_you_listened_to_for_year.py
@@ -61,7 +61,7 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
     def description():
         return "Generate a playlist of tracks released this year that you've listened to."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         recs = DataSetFetcherElement(server_url="https://bono.metabrainz.org/top-new-tracks/json",
                                      json_post_data=[{ 'user_name': inputs['user_name'] }])
 
@@ -69,7 +69,7 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         y_lookup.set_sources(recs)
 
         year = datetime.now().year
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % year, self.DESC % year)
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % year, self.DESC % year, patch_slug=self.slug())
         pl_maker.set_sources(recs)
 
         shaper = PlaylistRedundancyReducerElement()

--- a/troi/patches/top_recordings_for_year.py
+++ b/troi/patches/top_recordings_for_year.py
@@ -76,13 +76,19 @@ class TopTracksYearPatch(troi.patch.Patch):
     def description():
         return "Generate your year in review playlist."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         user_name = inputs['user_name']
 
         year = datetime.now().year
-        stats = troi.listenbrainz.stats.UserRecordingElement(user_name=user_name, count=self.max_num_recordings, time_range="this_year")
+        stats = troi.listenbrainz.stats.UserRecordingElement(user_name=user_name,
+                                                             count=self.max_num_recordings,
+                                                             time_range="this_year")
+        remove_empty = troi.filters.EmptyRecordingFilterElement()
+        remove_empty.set_sources(stats)
 
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, user_name), self.DESC % (quote(user_name), year))
-        pl_maker.set_sources(stats)
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, user_name),
+                                                      self.DESC % (quote(user_name), year),
+                                                      patch_slug=self.slug())
+        pl_maker.set_sources(remove_empty)
 
         return pl_maker

--- a/troi/patches/top_recordings_for_year.py
+++ b/troi/patches/top_recordings_for_year.py
@@ -23,23 +23,16 @@ class TopTracksYearPatch(troi.patch.Patch):
         See below for description
     """
 
-    NAME = "Top recordings of %d for %s"
+    NAME = "Top Recordings of %d for %s"
     DESC = """<p>
-              This playlist is made from your <a href="https://listenbrainz.org/user/%s/reports?range=year">
-              top recordings for %d statistics</a>.
+              This playlist is made from %s's Top Recordings for %d statistics.
               </p>
               <p>
-              Double click on any recording to start playing it -- we'll do our best to find a matching recording
-              to play. If you have Spotify, we recommend connecting your account for a better playback experience.
+              We selected the top tracks from this user’s statistics and removed those recordings that we could not
+              match to entries in MusicBrainz. (This is a requirement to make this list playable.)
               </p>
               <p>
-              Please keep in mind that this is our first attempt at making playlists for our users. Our processes
-              are not fully debugged and you may find that things are not perfect. So, if this playlist isn't
-              very accurate, we apologize -- we'll continue to make them better. (e.g. some recordings may be missing
-              from this list because we were not able to find a match for it in MusicBrainz.)
-              </p>
-              <p>
-              Happy holidays from everyone at MetaBrainz!
+              This is a review playlist that we hope will give insights into the listening habits of the year.
               </p>
            """
 

--- a/troi/patches/top_recordings_for_year.py
+++ b/troi/patches/top_recordings_for_year.py
@@ -81,14 +81,16 @@ class TopTracksYearPatch(troi.patch.Patch):
 
         year = datetime.now().year
         stats = troi.listenbrainz.stats.UserRecordingElement(user_name=user_name,
-                                                             count=self.max_num_recordings,
+                                                             count=(self.max_num_recordings*2),
                                                              time_range="this_year")
         remove_empty = troi.filters.EmptyRecordingFilterElement()
         remove_empty.set_sources(stats)
 
         pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year, user_name),
                                                       self.DESC % (quote(user_name), year),
-                                                      patch_slug=self.slug())
+                                                      patch_slug=self.slug(),
+                                                      user_name=user_name,
+                                                      max_num_recordings=self.max_num_recordings)
         pl_maker.set_sources(remove_empty)
 
         return pl_maker

--- a/troi/patches/top_recordings_for_year.py
+++ b/troi/patches/top_recordings_for_year.py
@@ -78,11 +78,14 @@ class TopTracksYearPatch(troi.patch.Patch):
 
     def create(self, inputs, patch_args):
         user_name = inputs['user_name']
+        auth_token = patch_args["token"]
 
         year = datetime.now().year
         stats = troi.listenbrainz.stats.UserRecordingElement(user_name=user_name,
                                                              count=(self.max_num_recordings*2),
-                                                             time_range="this_year")
+                                                             time_range="this_year",
+                                                             auth_token=auth_token)
+
         remove_empty = troi.filters.EmptyRecordingFilterElement()
         remove_empty.set_sources(stats)
 

--- a/troi/patches/top_sitewide_recordings_for_year.py
+++ b/troi/patches/top_sitewide_recordings_for_year.py
@@ -1,0 +1,93 @@
+from datetime import datetime 
+from collections import defaultdict
+from urllib.parse import quote
+import requests
+
+import click
+
+from troi import Element, Artist, Recording, Playlist, PipelineError
+import troi.listenbrainz.stats
+import troi.filters
+import troi.sorts
+import troi.musicbrainz.recording_lookup
+import troi.musicbrainz.mbid_reader
+import troi.playlist
+
+
+@click.group()
+def cli():
+    pass
+
+
+class TopSitewideRecordingsPatch(troi.patch.Patch):
+    """
+        See below for description
+    """
+
+    NAME = "Most Listened to Recordings for %d"
+    DESC = """<p>
+              This playlist is comprised of the top recordings that ListenBrainz users listened to at least once in %d.
+              </p>
+              <p>
+              This playlist serves as an insight to what other users on ListenBrainz are listening to. There is
+              very little guarantee that you may like any of these tracks, so we consider this playlist to be a discovery
+              playlist.  Because of this, it may require more active listening since it may contain tracks
+              that are not fully to your taste.
+              </p>
+           """
+
+    def __init__(self, debug=False, max_num_recordings=50):
+        troi.patch.Patch.__init__(self, debug)
+        self.max_num_recordings = max_num_recordings
+
+    @staticmethod
+    @cli.command(no_args_is_help=True)
+    @click.argument('file_name')
+    def parse_args(**kwargs):
+        """
+        Generate the ListenBrainz site wide top recordings for year playlist.
+
+        \b
+        FILE_NAME: The filename that contains the recording_mbids for this playlist.
+        """
+
+        return kwargs
+
+    @staticmethod
+    def inputs():
+        return [{ "type": str, "name": "file_name", "desc": "Recoding MBID file", "optional": False }]
+
+    @staticmethod
+    def outputs():
+        return [Recording]
+
+    @staticmethod
+    def slug():
+        return "top-sitewide-recordings-for-year"
+
+    @staticmethod
+    def description():
+        return "Generate top sitewide recorings for year playlist"
+
+    def create(self, inputs, patch_args):
+        file_name = inputs['file_name']
+        auth_token = patch_args["token"]
+        year = datetime.now().year
+
+        recs = troi.musicbrainz.mbid_reader.MBIDReaderElement(file_name)
+
+        rec_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
+        rec_lookup.set_sources(recs)
+
+        remove_empty = troi.filters.EmptyRecordingFilterElement()
+        remove_empty.set_sources(rec_lookup)
+
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year),
+                                                      self.DESC % (year),
+                                                      patch_slug=self.slug())
+        pl_maker.set_sources(remove_empty)
+
+        shaper = troi.playlist.PlaylistRedundancyReducerElement(max_artist_occurance=1, max_num_recordings=self.max_num_recordings)
+        shaper.set_sources(pl_maker)
+
+        return shaper

--- a/troi/patches/weekly_flashback_jams.py
+++ b/troi/patches/weekly_flashback_jams.py
@@ -105,7 +105,7 @@ class WeeklyFlashbackJams(troi.patch.Patch):
     def description():
         return "Generate weekly flashback playlists from the ListenBrainz recommended recordings."
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
         user_name = inputs['user_name']
         type = inputs['type']
 

--- a/troi/patches/world_trip.py
+++ b/troi/patches/world_trip.py
@@ -155,7 +155,7 @@ class WorldTripPatch(troi.patch.Patch):
     def description():
         return "Generate a playlist for a given continent"
 
-    def create(self, inputs):
+    def create(self, inputs, patch_args):
 
         if inputs["sort"] not in ("longitude", "latitude"):
             raise PipelineError("Argument sort must be either 'longitude' or 'latitude'.")

--- a/troi/patches/yim_patch_runner.py
+++ b/troi/patches/yim_patch_runner.py
@@ -2,7 +2,7 @@ import click
 
 import troi
 from troi import Element, Artist, Recording, Playlist, PipelineError
-from troi.listenbrainz.user import UserListElement
+from troi.listenbrainz.yim_user import YIMUserListElement
 from troi.loops import ForLoopElement
 from troi.playlist import PlaylistElement
 
@@ -63,14 +63,12 @@ class YIMRunnerPatch(troi.patch.Patch):
     @staticmethod
     @cli.command(no_args_is_help=True)
     @click.argument('patch_slugs')
-    @click.argument('user_names', nargs=-1)
     def parse_args(**kwargs):
         """
-        Run a patch for a number of users.
+        Run YIM patch for users in the LB DB
 
         \b
         PATCH_SLUG: The slug of the patch to run.
-        USER_NAMES: The list of ListenBrainz user names to run the patch for.
         """
 
         return kwargs
@@ -95,14 +93,12 @@ class YIMRunnerPatch(troi.patch.Patch):
         return "Run a given patch for a given list users."
 
     def create(self, inputs, patch_args):
-        user_names = inputs["user_names"]
-
         patch_slugs = [ slug for slug in inputs["patch_slugs"].split(",") ]
         print("Running the following patches:")
         for slug in patch_slugs:
             print("  %s" % slug)
 
-        u = UserListElement(user_names)
+        u = YIMUserListElement()
         
         for_loop = ForLoopElement(patch_slugs, inputs, patch_args)
         for_loop.set_sources(u)

--- a/troi/patches/yim_patch_runner.py
+++ b/troi/patches/yim_patch_runner.py
@@ -6,8 +6,6 @@ from troi.listenbrainz.yim_user import YIMUserListElement
 from troi.loops import ForLoopElement
 from troi.playlist import PlaylistElement
 
-from icecream import ic
-
 
 @click.group()
 def cli():
@@ -37,7 +35,7 @@ class YIMSubmitterElement(Element):
 
         slug = inputs[0][0].patch_slug
         metadata = { "source_patch": slug }
-        with open("%s-playlists.json" % slug, "a") as f:
+        with open("%s-playlists.json" % slug, "w") as f:
             print("YIMSubmitter:")
             for playlist in inputs[0]:
                 print("  ", playlist.patch_slug, playlist.user_name)

--- a/troi/patches/yim_patch_runner.py
+++ b/troi/patches/yim_patch_runner.py
@@ -42,6 +42,7 @@ class YIMSubmitterElement(Element):
             for playlist in inputs[0]:
                 print("  ", playlist.patch_slug, playlist.user_name)
                 f.write("%s\n" % playlist.user_name)
+                f.write("%s\n" % playlist.mbid)
 
                 # This is hacky and should be moved to playlist
                 playlist_element = PlaylistElement()

--- a/troi/patches/yim_patch_runner.py
+++ b/troi/patches/yim_patch_runner.py
@@ -38,6 +38,9 @@ class YIMSubmitterElement(Element):
         with open("%s-playlists.json" % slug, "w") as f:
             print("YIMSubmitter:")
             for playlist in inputs[0]:
+                if len(playlist.recordings) == 0:
+                    continue
+
                 print("  ", playlist.patch_slug, playlist.user_name)
                 f.write("%s\n" % playlist.user_name)
                 f.write("%s\n" % playlist.mbid)

--- a/troi/patches/yim_patch_runner.py
+++ b/troi/patches/yim_patch_runner.py
@@ -32,6 +32,9 @@ class YIMSubmitterElement(Element):
 
     def read(self, inputs):
 
+        if len(inputs) == 0 or len(inputs[0]) == 0:
+            return None
+
         slug = inputs[0][0].patch_slug
         metadata = { "source_patch": slug }
         with open("%s-playlists.json" % slug, "a") as f:
@@ -77,7 +80,7 @@ class YIMRunnerPatch(troi.patch.Patch):
     def inputs():
         return [
                    { "type": str, "name": "patch_slugs", "desc": "List of Troi patches name to execute (separated by comman, no spaces!)", "optional": False },
-                   { "type": list, "name": "user_names", "desc": "ListenBrainz user names", "optional": False }
+                   { "type": list, "name": "user_names", "desc": "ListenBrainz user names", "optional": True }
                ]
 
     @staticmethod

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -236,7 +236,6 @@ class PlaylistRedundancyReducerElement(Element):
                 artists = defaultdict(int)
                 for r in playlist.recordings:
                     for mbid in r.artist.mbids:
-                        print(mbid)
                         artists[mbid] += 1
                     for mbid in r.artist.mbids:
                         if artists[mbid] > max_artist_occurance:

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -301,12 +301,13 @@ class PlaylistMakerElement(Element):
         This element takes in Recordings and spits out a Playlist.
     '''
 
-    def __init__(self, name, desc, patch_slug=None, max_tracks=None):
+    def __init__(self, name, desc, patch_slug=None, user_name=None, max_num_recordings=None):
         super().__init__()
         self.name = name
         self.desc = desc
         self.patch_slug = patch_slug
-        self.max_tracks = max_tracks
+        self.user_name = user_name
+        self.max_num_recordings = max_num_recordings
 
     @staticmethod
     def inputs():
@@ -317,14 +318,16 @@ class PlaylistMakerElement(Element):
         return [Playlist]
 
     def read(self, inputs):
-        if self.max_tracks is not None:
+        if self.max_num_recordings is not None:
             return [Playlist(name=self.name,
                     description=self.desc,
-                    recordings=inputs[0][:self.max_tracks],
-                    patch_slug=self.patch_slug)]
+                    recordings=inputs[0][:self.max_num_recordings],
+                    patch_slug=self.patch_slug,
+                    user_name=self.user_name)]
         else:
             return [Playlist(name=self.name,
                     description=self.desc,
                     recordings=inputs[0],
-                    patch_slug=self.patch_slug)]
+                    patch_slug=self.patch_slug,
+                    user_name=self.user_name)]
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -225,14 +225,15 @@ class PlaylistRedundancyReducerElement(Element):
 
     def read(self, inputs):
 
-        kept = []
         playlists = []
 
         max_artist_occurance = self.max_artist_occurance
         for playlist in inputs[0]:
             while True:
+                kept = []
                 artists = defaultdict(int)
                 for r in playlist.recordings:
+
                     for mbid in r.artist.mbids:
                         artists[mbid] += 1
                     for mbid in r.artist.mbids:
@@ -247,7 +248,7 @@ class PlaylistRedundancyReducerElement(Element):
                 else:
                     max_artist_occurance += 1
                     if max_artist_occurance > 4:
-                        playlist.recordings = playlist.recordings[:self.max_num_recordings]
+                        playlist.recordings = kept
                         break
 
         return inputs[0]
@@ -351,4 +352,3 @@ class PlaylistMakerElement(Element):
                     recordings=inputs[0],
                     patch_slug=self.patch_slug,
                     user_name=self.user_name)]
-

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -144,7 +144,7 @@ class PlaylistElement(Element):
             with open(filename, "w") as f:
                 f.write(json.dumps(_serialize_to_jspf(playlist, track_count)))
 
-    def submit(self, token, created_for):
+    def submit(self, token, created_for=None):
         """
             Submit the playlist to ListenBrainz.
 
@@ -301,10 +301,11 @@ class PlaylistMakerElement(Element):
         This element takes in Recordings and spits out a Playlist.
     '''
 
-    def __init__(self, name, desc, max_tracks=None):
+    def __init__(self, name, desc, patch_slug=None, max_tracks=None):
         super().__init__()
         self.name = name
         self.desc = desc
+        self.patch_slug = patch_slug
         self.max_tracks = max_tracks
 
     @staticmethod
@@ -317,6 +318,13 @@ class PlaylistMakerElement(Element):
 
     def read(self, inputs):
         if self.max_tracks is not None:
-            return [Playlist(name=self.name, description=self.desc, recordings=inputs[0][:self.max_tracks])]
+            return [Playlist(name=self.name,
+                    description=self.desc,
+                    recordings=inputs[0][:self.max_tracks],
+                    patch_slug=self.patch_slug)]
         else:
-            return [Playlist(name=self.name, description=self.desc, recordings=inputs[0])]
+            return [Playlist(name=self.name,
+                    description=self.desc,
+                    recordings=inputs[0],
+                    patch_slug=self.patch_slug)]
+

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -15,7 +15,16 @@ PLAYLIST_RELEASE_URI_PREFIX = "https://musicbrainz.org/release/"
 PLAYLIST_URI_PREFIX = "https://listenbrainz.org/playlist/"
 PLAYLIST_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#playlist"
 
-def _serialize_to_jspf(playlist, created_for=None):
+def _serialize_to_jspf(playlist, created_for=None, track_count=None):
+    """
+        Serialize a playlist to JSPF.
+
+        Arguments:
+            created_for: The user name of the user for whom this playlist
+                         was created.
+            track_count: The number of tracks to serialize. If not provided,
+                         all tracks will be serialized.
+    """
 
     data = { "creator": "ListenBrainz Troi",
              "extension": {
@@ -120,8 +129,12 @@ class PlaylistElement(Element):
                     continue
                 self.print_recording.print(recording)
 
-    def save(self):
-        """Save each playlist to disk, giving each playlist a unique name if none was provided."""
+    def save(self, track_count=None):
+        """Save each playlist to disk, giving each playlist a unique name if none was provided.
+
+           Arguments:
+              track_count: If provided, write out only this many tracks to the playlist/
+        """
 
         if not self.playlists:
             raise PipelineError("Playlists have not been generated yet.")
@@ -129,7 +142,7 @@ class PlaylistElement(Element):
         for i, playlist in enumerate(self.playlists):
             filename = playlist.filename or "playlist_%03d.jspf" % i
             with open(filename, "w") as f:
-                f.write(json.dumps(_serialize_to_jspf(playlist)))
+                f.write(json.dumps(_serialize_to_jspf(playlist, track_count)))
 
     def submit(self, token, created_for):
         """

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -177,7 +177,7 @@ class PlaylistElement(Element):
         for playlist in self.playlists:
             print("submit %d tracks" % len(playlist.recordings))
             if len(playlist.recordings) == 0:
-                print("skip playlist of length 0")
+                print("skip submitting a zero length playlist.")
                 continue
 
             r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -176,11 +176,10 @@ class PlaylistElement(Element):
 
         playlist_mbids = []
         for playlist in self.playlists:
-            print("submit %d tracks" % len(playlist.recordings))
             if len(playlist.recordings) == 0:
-                print("skip submitting a zero length playlist.")
                 continue
 
+            print("submit %d tracks" % len(playlist.recordings))
             r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,
                               json=_serialize_to_jspf(playlist, created_for, algorithm_metadata=algorithm_metadata),
                               headers={"Authorization": "Token " + str(token)})

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -229,7 +229,6 @@ class PlaylistRedundancyReducerElement(Element):
         kept = []
         playlists = []
 
-        from icecream import ic
         max_artist_occurance = self.max_artist_occurance
         for playlist in inputs[0]:
             while True:

--- a/troi/print_recording.py
+++ b/troi/print_recording.py
@@ -85,6 +85,8 @@ class PrintRecordingList():
             rec_name = recording.name
         print("%-60s %-50s %5s" % (rec_name[:59], artist[:49], recording.mbid[:5]), end='')
 
+        if recording.artist.artist_credit_id is not None:
+            print(" %8d" % recording.artist.artist_credit_id, end='')
         if self.print_year or year:
             print(" %d" % recording.year, end='')
         if self.print_listen_count or listen_count:

--- a/troi/print_recording.py
+++ b/troi/print_recording.py
@@ -85,6 +85,8 @@ class PrintRecordingList():
             rec_name = recording.name
         print("%-60s %-50s %5s" % (rec_name[:59], artist[:49], recording.mbid[:5]), end='')
 
+        if recording.artist.mbids is not None:
+            print(" %-20s" % ",".join([ mbid[:5] for mbid in recording.artist.mbids ]), end='')
         if recording.artist.artist_credit_id is not None:
             print(" %8d" % recording.artist.artist_credit_id, end='')
         if self.print_year or year:

--- a/troi/print_recording.py
+++ b/troi/print_recording.py
@@ -83,8 +83,7 @@ class PrintRecordingList():
             rec_name = "[[ mbid:%s ]]" % recording.mbid
         else:
             rec_name = recording.name
-        print("%-60s %-50s" % (rec_name[:59], artist[:49]), end='')
-        print(" %s" % recording.mbid, end='')
+        print("%-60s %-50s %5s" % (rec_name[:59], artist[:49], recording.mbid[:5]), end='')
 
         if self.print_year or year:
             print(" %d" % recording.year, end='')

--- a/troi/print_recording.py
+++ b/troi/print_recording.py
@@ -84,6 +84,7 @@ class PrintRecordingList():
         else:
             rec_name = recording.name
         print("%-60s %-50s" % (rec_name[:59], artist[:49]), end='')
+        print(" %s" % recording.mbid, end='')
 
         if self.print_year or year:
             print(" %d" % recording.year, end='')


### PR DESCRIPTION
This PR covers the work finishing YIM 2021 -- once again there are no tests, but a lot of code hammered out quickly to meet the deadline. The next PR will revisit tests for all the newly added features.

This PR implements the following:

- Add a user entity
- Add the concept of a script runner that can run scripts for a whole pile of users.
- Add the ability to query for active LB users.
- Some type checking debugging
- Improvements to what data elements an artist can have to make things more flexible.
- Cleanup of command line arguments to make submitting data for multiple users more clear
- Finish debugging the 4 patches used to create the YIM playlists.

The next PR will need to do some cleanup refactoring and add tests for all the new functions.