### PR TITLE
LB-1058: Fix jspf playlist output 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ click==7.1.2
 ujson==2.0.3
 requests==2.24.0
 pytest==5.4.3
+psycopg2-binary==2.9.3
 countryinfo==0.1.2
 git+https://github.com/paramsingh/pylistenbrainz.git@v0.4.1#egg=pylistenbrainz

--- a/troi/acousticbrainz/tests/test_annoy.py
+++ b/troi/acousticbrainz/tests/test_annoy.py
@@ -57,7 +57,7 @@ class TestAnnoyLookupElement(unittest.TestCase):
 
         entities = e.read([[]])
         req.assert_called_with(e.SERVER_URL + "mfccs/", params={
-            "remove_dups": "true", "recording_ids": "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0"
+            "remove_dups": "all", "recording_ids": "8f8cc91f-0bca-4351-90d4-ef334ac0a0cf:0", 'n_neighbours': 1000
         })
 
         assert len(entities) == 6

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -14,6 +14,7 @@ PLAYLIST_ARTIST_URI_PREFIX = "https://musicbrainz.org/artist/"
 PLAYLIST_RELEASE_URI_PREFIX = "https://musicbrainz.org/release/"
 PLAYLIST_URI_PREFIX = "https://listenbrainz.org/playlist/"
 PLAYLIST_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#playlist"
+PLAYLIST_TRACK_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#track"
 
 def _serialize_to_jspf(playlist, created_for=None, track_count=None, algorithm_metadata=None):
     """
@@ -60,8 +61,8 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None, algorithm_m
         track["identifier"] = "https://musicbrainz.org/recording/" + str(e.mbid)
         if artist_mbids:
             track["extension"] = {
-                PLAYLIST_TRACK_URI_PREFIX: {
-                    "artist_mbids" : artist_mbids,
+                PLAYLIST_TRACK_EXTENSION_URI: {
+                    "artist_identifiers": artist_mbids,
                 }
             }
         tracks.append(track)

--- a/troi/tests/test_filters.py
+++ b/troi/tests/test_filters.py
@@ -87,7 +87,7 @@ class TestArtistCreditLimiterElement(unittest.TestCase):
         assert plist[1].recordings[1].mbid == "73a9d0db-0ec7-490e-9a85-0525a5ccef8e"
 
 
-class TestDuplicateRecordingFilterElement(unittest.TestCase):
+class TestDuplicateRecordingMBIDFilterElement(unittest.TestCase):
     def test_duplicate_recording_filter_element(self):
         rlist = [Recording(mbid='8756f690-18ca-488d-a456-680fdaf234bd'),
                  Recording(mbid='8756f690-18ca-488d-a456-680fdaf234bd'),
@@ -96,7 +96,7 @@ class TestDuplicateRecordingFilterElement(unittest.TestCase):
                  Recording(mbid='8756f690-18ca-488d-a456-680fdaf234bd'),
                  Recording(mbid='73a9d0db-0ec7-490e-9a85-0525a5ccef8e'),
                  Recording(mbid='139654ae-2c02-4e0f-aee0-c47da6e59ff1')]
-        e = troi.filters.DuplicateRecordingFilterElement()
+        e = troi.filters.DuplicateRecordingMBIDFilterElement()
         flist = e.read([rlist])
         assert len(flist) == 3
 

--- a/troi/tests/test_utils.py
+++ b/troi/tests/test_utils.py
@@ -9,7 +9,7 @@ class TestPatches(unittest.TestCase):
     def test_discover_patches(self):
         patches = discover_patches()
 
-        assert len(patches) == 4
+        assert len(patches) == 12
         assert "daily-jams" in patches
         assert "area-random-recordings" in patches
         assert "ab-similar-recordings" in patches


### PR DESCRIPTION
we had 2 inconsistencies in the troi jspf output compared to the
documentation:
 - track extension was https://musicbrainz.org/recording/ instead of
   https://musicbrainz.org/doc/jspf#track
 - key for the list of artist mbids was changed from artist_identifier
   to artist_mbids, and we can't find a documentated motivation for
   doing so. After discussion we decided to standardise on
   artist_identifiers (plural, and keeps the 'identifier' terminology
   already present in the jspf spec