### PR TITLE
Fix area random recordings

### DIFF
--- a/troi/tools/area_lookup.py
+++ b/troi/tools/area_lookup.py
@@ -22,4 +22,4 @@ def area_lookup(area_name):
     if len(rows) == 0:
         raise PipelineError("Cannot find area name. Must be spelled exactly as in MusicBrainz.")
 
-    return rows[0]['area_id']
+    return rows[0]['area_mbid']

--- a/troi/tools/tests/test_area_lookup.py
+++ b/troi/tools/tests/test_area_lookup.py
@@ -13,7 +13,7 @@ request_json = [
 
 return_json = [
     {
-        "area_id": 81,
+        "area_mbid": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
         "area_name": "Germany"
     }
 ]
@@ -30,4 +30,4 @@ class TestAreaLookup(unittest.TestCase):
         area_id = troi.tools.area_lookup.area_lookup(request_json[0]["[area]"])
         req.assert_called_with(troi.tools.area_lookup.AREA_LOOKUP_SERVER_URL, json=request_json)
 
-        assert area_id == 81
+        assert area_id == "85752fda-13c4-31a3-bee5-0e5cb1f51dad"


### PR DESCRIPTION
Quick fix to get the random area recordings working again. Still no tests. Changes include:

- Fetch artist mbids
- Fetch artist area mbid, not id
- Use dataset hoster to fetch the data, remove the old unneeded file
- Use improved PlaylistRedundancyReducerElement