### PR TITLE
Improve daily jams

### DIFF
--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -19,11 +19,12 @@ class DailyJamsElement(Element):
         Split weekly recommended recordings into 7 sets, one for each day of the week.
     '''
 
-    def __init__(self, recs, user, day):
+    def __init__(self, recs, user, day, slug):
         Element.__init__(self)
         self.recs = recs
         self.user = user
         self.day = day
+        self.slug = slug
 
     @staticmethod
     def inputs():
@@ -47,7 +48,9 @@ class DailyJamsElement(Element):
         jam_date += timedelta(days=self.day)
         jam_date = jam_date.strftime("%Y-%m-%d %a")
 
-        return [ Playlist(name="Daily Jams for %s, %s" % (self.user, jam_date), recordings=days[self.day - 1]) ]
+        return [ Playlist(name="Daily Jams for %s, %s" % (self.user, jam_date),
+                          recordings=days[self.day - 1],
+                          patch_slug=self.slug) ]
 
 
 class DailyJamsPatch(troi.patch.Patch):
@@ -117,7 +120,7 @@ class DailyJamsPatch(troi.patch.Patch):
             artist_limiter = troi.filters.ArtistCreditLimiterElement(count=3)
         artist_limiter.set_sources(artist_filter)
 
-        jams = DailyJamsElement(recs, user=user_name, day=day)
+        jams = DailyJamsElement(recs, user=user_name, day=day, slug=DailyJamsPatch.slug())
         jams.set_sources(artist_limiter)
 
         return jams

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -34,12 +34,12 @@ class ZipperElement(Element):
 
     def read(self, inputs):
         output = []
-        for rec in zip_longest(inputs[0], inputs[1]):
-            if rec[0] is not None:
-                output.append(rec[0])
-            if rec[1] is not None:
-                output.append(rec[1])
-           
+        for rec0, rec1 in zip_longest(inputs[0], inputs[1]):
+            if rec0 is not None:
+                output.append(rec0)
+            if rec1 is not None:
+                output.append(rec1)
+
         return output
 
 
@@ -83,7 +83,6 @@ class DailyJamsPatch(troi.patch.Patch):
         top_recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
         top_recs_lookup.set_sources(top_recs)
 
-
         sim_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name=user_name,
                                                                               artist_type="similar",
                                                                               count=100)
@@ -93,10 +92,10 @@ class DailyJamsPatch(troi.patch.Patch):
         zipper = ZipperElement()
         zipper.set_sources([top_recs_lookup, sim_recs_lookup])
 
-        jam_date = datetime.utcnow() 
+        jam_date = datetime.utcnow()
         jam_date = jam_date.strftime("%Y-%m-%d %a")
 
-        pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date), 
+        pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date),
                                         desc="Daily jams playlist!",
                                         patch_slug=self.slug)
         pl_maker.set_sources(zipper)

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
+from itertools import zip_longest
 import random
 
 import click
 
 from troi import Element, PipelineError, Recording, Playlist
+from troi.playlist import PlaylistRedundancyReducerElement, PlaylistMakerElement, PlaylistShuffleElement
 import troi.listenbrainz.recs
 import troi.filters
 import troi.musicbrainz.recording_lookup
@@ -14,43 +16,31 @@ def cli():
     pass
 
 
-class DailyJamsElement(Element):
+class ZipperElement(Element):
     '''
-        Split weekly recommended recordings into 7 sets, one for each day of the week.
+        Given two or more inputs, pick recordings from each alternatingly
     '''
 
-    def __init__(self, recs, user, day, slug):
+    def __init__(self):
         Element.__init__(self)
-        self.recs = recs
-        self.user = user
-        self.day = day
-        self.slug = slug
 
     @staticmethod
     def inputs():
-        return [Recording]
+        return [Recording, Recording]
 
     @staticmethod
     def outputs():
-        return [Playlist]
+        return [Recording]
 
     def read(self, inputs):
-        recordings = inputs[0]
-        if not recordings or len(recordings) == 0:
-            return []
-
-        random.seed(self.recs.last_updated)
-        random.shuffle(recordings)
-        num_per_day = len(recordings) // 7
-        days = [recordings[i:i + num_per_day] for i in range(0, len(recordings), num_per_day)]
-
-        jam_date = datetime.utcnow() - timedelta(days=datetime.utcnow().isoweekday() % 7)
-        jam_date += timedelta(days=self.day)
-        jam_date = jam_date.strftime("%Y-%m-%d %a")
-
-        return [ Playlist(name="Daily Jams for %s, %s" % (self.user, jam_date),
-                          recordings=days[self.day - 1],
-                          patch_slug=self.slug) ]
+        output = []
+        for rec in zip_longest(inputs[0], inputs[1]):
+            if rec[0] is not None:
+                output.append(rec[0])
+            if rec[1] is not None:
+                output.append(rec[1])
+           
+        return output
 
 
 class DailyJamsPatch(troi.patch.Patch):
@@ -62,16 +52,12 @@ class DailyJamsPatch(troi.patch.Patch):
     @staticmethod
     @cli.command(no_args_is_help=True)
     @click.argument('user_name')
-    @click.argument('type')
-    @click.argument('day', required=False, type=int)
     def parse_args(**kwargs):
         """
         Generate a daily playlist from the ListenBrainz recommended recordings.
 
         \b
         USER_NAME is a MusicBrainz user name that has an account on ListenBrainz.
-        TYPE is The type of daily jam. Must be 'top' or 'similar'.
-        DAY is The day of the week to generate jams for (1 = Monday, 2 = Tuesday, 7 = Sunday). Leave blank for today.
         """
 
         return kwargs
@@ -86,41 +72,39 @@ class DailyJamsPatch(troi.patch.Patch):
 
     @staticmethod
     def description():
-        return "Generate a daily playlist from the ListenBrainz recommended recordings. Day 1 = Monday, Day 2  = Tuesday ..."
+        return "Generate a daily playlist from the ListenBrainz recommended recordings."
 
     def create(self, inputs, patch_args):
         user_name = inputs['user_name']
-        type = inputs['type']
-        day = inputs['day']
-        if day is None:
-            day = 0
 
-        if day > 7:
-            raise PipelineError("day must be an integer between 0-7.")
-        if day == 0:
-            day = datetime.today().weekday() + 1
-
-        if type not in ("top", "similar"):
-            raise PipelineError("type must be either 'top' or 'similar'")
+        top_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name=user_name,
+                                                                              artist_type="top",
+                                                                              count=100)
+        top_recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
+        top_recs_lookup.set_sources(top_recs)
 
 
-        recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name=user_name,
-                                                                          artist_type=type,
-                                                                          count=-1)
-        r_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
-        r_lookup.set_sources(recs)
+        sim_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name=user_name,
+                                                                              artist_type="similar",
+                                                                              count=100)
+        sim_recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
+        sim_recs_lookup.set_sources(sim_recs)
 
-        # If an artist should never appear in a playlist, add the artist_credit_id here
-        artist_filter = troi.filters.ArtistCreditFilterElement([])
-        artist_filter.set_sources(r_lookup)
+        zipper = ZipperElement()
+        zipper.set_sources([top_recs_lookup, sim_recs_lookup])
 
-        if type == "top":
-            artist_limiter = troi.filters.ArtistCreditLimiterElement(count=9)
-        else:
-            artist_limiter = troi.filters.ArtistCreditLimiterElement(count=3)
-        artist_limiter.set_sources(artist_filter)
+        jam_date = datetime.utcnow() 
+        jam_date = jam_date.strftime("%Y-%m-%d %a")
 
-        jams = DailyJamsElement(recs, user=user_name, day=day, slug=DailyJamsPatch.slug())
-        jams.set_sources(artist_limiter)
+        pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date), 
+                                        desc="Daily jams playlist!",
+                                        patch_slug=self.slug)
+        pl_maker.set_sources(zipper)
 
-        return jams
+        reducer = PlaylistRedundancyReducerElement()
+        reducer.set_sources(pl_maker)
+
+        shuffle = PlaylistShuffleElement()
+        shuffle.set_sources(reducer)
+
+        return shuffle

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -8,8 +8,7 @@ from troi.operations import is_homogeneous
 from troi.print_recording import PrintRecordingList
 
 LISTENBRAINZ_SERVER_URL = "https://listenbrainz.org"
-LISTENBRAINZ_API_URL = "http://localhost:8100"
-#LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
+LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
 LISTENBRAINZ_PLAYLIST_CREATE_URL = LISTENBRAINZ_API_URL + "/1/playlist/create"
 PLAYLIST_TRACK_URI_PREFIX = "https://musicbrainz.org/recording/"
 PLAYLIST_ARTIST_URI_PREFIX = "https://musicbrainz.org/artist/"

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -8,7 +8,8 @@ from troi.operations import is_homogeneous
 from troi.print_recording import PrintRecordingList
 
 LISTENBRAINZ_SERVER_URL = "https://listenbrainz.org"
-LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
+LISTENBRAINZ_API_URL = "http://localhost:8100"
+#LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
 LISTENBRAINZ_PLAYLIST_CREATE_URL = LISTENBRAINZ_API_URL + "/1/playlist/create"
 PLAYLIST_TRACK_URI_PREFIX = "https://musicbrainz.org/recording/"
 PLAYLIST_ARTIST_URI_PREFIX = "https://musicbrainz.org/artist/"
@@ -185,6 +186,8 @@ class PlaylistElement(Element):
                 continue
 
             print("submit %d tracks" % len(playlist.recordings))
+            if algorithm_metadata is None and playlist.patch_slug is not None:
+                algorithm_metadata = { "source_patch": playlist.patch_slug }
             r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,
                               json=_serialize_to_jspf(playlist, created_for, algorithm_metadata=algorithm_metadata),
                               headers={"Authorization": "Token " + str(token)})


### PR DESCRIPTION
Before delving in and making daily-jams super fancy, I've made a simple stop-gap measure that zips together the top and similar recs, removes duplicate tracks and shuffles the result. This PR goes hand in hand with LB PR #2016. Once this is merged we should tag it and then reference that tag in the LB PR. 