### PR TITLE
Fix serialization issue in daily jams

### DIFF
--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -97,7 +97,7 @@ class DailyJamsPatch(troi.patch.Patch):
 
         pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date),
                                         desc="Daily jams playlist!",
-                                        patch_slug=self.slug)
+                                        patch_slug=self.slug())
         pl_maker.set_sources(zipper)
 
         reducer = PlaylistRedundancyReducerElement()


### PR DESCRIPTION
The patch to upload the generated playlist was failing because we are the function instead of its return value to the serialization function.