### PR TITLE
Use version ranges instead of pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-click==7.1.2
-ujson==5.4.0
-requests==2.28.0
-psycopg2-binary==2.9.3
-countryinfo==0.1.2
+click>=8.0
+ujson>=5.4.0
+requests
+psycopg2-binary>=2.9.3
+countryinfo>=0.1.2
 pylistenbrainz@git+https://github.com/metabrainz/pylistenbrainz.git@v0.5.2
-python-dateutil==2.8.2
+python-dateutil>=2.8.2


### PR DESCRIPTION
Since we generate install_requires in setup.py from requirements.txt now, the dependencies versions should be open ended so that the application using troi as a library can install the appropriate versions. Otherwise, installing dependencies will fail with a version conflict error.