### PR TITLE
Refactor generate_playlist

### DIFF
--- a/troi/core.py
+++ b/troi/core.py
@@ -1,72 +1,65 @@
 #!/usr/bin/env python3
 
 import sys
+from typing import Dict
 
 import click
 
 import troi
 import troi.playlist
 import troi.utils
+from troi.patch import Patch
+
+default_patch_args = dict(
+    debug=False,
+    echo=True,
+    save=False,
+    token=None,
+    upload=False,
+    args=None,
+    created_for=None,
+    name=None,
+    desc=None,
+    min_recordings=10
+)
 
 
-def generate_playlist(patch, debug=False, echo=True, save=False, token=None, upload=False, args=None,
-                      created_for=None, name="", desc="", min_recordings=10):
+def generate_playlist(patch: Patch, pipeline_args: Dict, supplied_patch_args: Dict):
     """
     Generate a playlist using a patch
 
-    patch: The patch slug that identifies the patch to run
-    debug: Print debug information or not
-    args: Other parameters that might need to be passed to the patch [optional]
-    print: This option causes the generated playlist to be printed to stdout.
-    save: The save option causes the generated playlist to be saved to disk.
-    token: Auth token to use when using the LB API. Required for submitting playlists to the server.
-           See https://listenbrainz.org/profile to get your user token.
-    upload: Whether or not to submit the finished playlist to the LB server. Token must be set for this to work.
-    created-for: If this option is specified, it must give a valid user name and the
-                 TOKEN argument must specify a user who is whitelisted as a playlist bot at
-                 listenbrainz.org .
-    name: Override the algorithms that generate a playlist name and use this name instead.
-    desc: Override the algorithms that generate a playlist description and use this description instead.
-    min-recordings: The minimum number of recordings that must be present in a playlist to consider it complete.
-                    If it doesn't have sufficient numbers of tracks, ignore the playlist and don't submit it.
-                    Default: Off, a playlist with at least one track will be considere complete.
+    patch: the patch to run
+    pipeline_args: the arguments to pass to the entire pipeline
+    patch_args: the arguments passed to the topmost patch. this dict supports the following keys currently:
+        debug: Print debug information or not
+        args: Other parameters that might need to be passed to the patch [optional]
+        print: This option causes the generated playlist to be printed to stdout.
+        save: The save option causes the generated playlist to be saved to disk.
+        token: Auth token to use when using the LB API. Required for submitting playlists to the server.
+               See https://listenbrainz.org/profile to get your user token.
+        upload: Whether or not to submit the finished playlist to the LB server. Token must be set for this to work.
+        created-for: If this option is specified, it must give a valid user name and the
+                     TOKEN argument must specify a user who is whitelisted as a playlist bot at
+                     listenbrainz.org .
+        name: Override the algorithms that generate a playlist name and use this name instead.
+        desc: Override the algorithms that generate a playlist description and use this description instead.
+        min-recordings: The minimum number of recordings that must be present in a playlist to consider it complete.
+                        If it doesn't have sufficient numbers of tracks, ignore the playlist and don't submit it.
+                        Default: Off, a playlist with at least one track will be considere complete.
     """
-
-    if args is None:
-        args = []
-
-    patchname = patch
-    patches = troi.utils.discover_patches()
-    if patch not in patches:
-        print("Cannot load patch '%s'. Use the list command to get a list of available patches." % patch,
-              file=sys.stderr)
-        return None
-
-    patch = patches[patch](debug)
-
-    context = patch.parse_args.make_context(patchname, list(args))
-    pipelineargs = context.forward(patch.parse_args)
-
-    patch_args = {
-        "echo": echo,
-        "save": save,
-        "token": token,
-        "created_for": created_for, 
-        "upload": upload, 
-        "name": name,
-        "desc": desc,
-        "min_recordings": min_recordings
-    }
-
-    pipeline = patch.create(pipelineargs, patch_args)
+    patch_args = {**default_patch_args, **supplied_patch_args}
+    pipeline = patch.create(pipeline_args, patch_args)
     try:
         playlist = troi.playlist.PlaylistElement()
         playlist.set_sources(pipeline)
         print("Troi playlist generation starting...")
         result = playlist.generate()
 
+        name = patch_args["name"]
         if name:
             playlist.playlists[0].name = name
+
+        desc = patch_args["desc"]
         if desc:
             playlist.playlists[0].descripton = desc
 
@@ -75,23 +68,29 @@ def generate_playlist(patch, debug=False, echo=True, save=False, token=None, upl
         print("Failed to generate playlist: %s" % err, file=sys.stderr)
         return None
 
+    upload = patch_args["upload"]
+    token = patch_args["token"]
     if upload and not token:
         print("In order to upload a playlist, you must provide an auth token. Use option --token.")
         return None
 
+    min_recordings = patch_args["min_recordings"]
     if min_recordings is not None and \
-        (len(playlist.playlists) == 0 or len(playlist.playlists[0].recordings) < min_recordings):
+            (len(playlist.playlists) == 0 or len(playlist.playlists[0].recordings) < min_recordings):
         print("Playlist does not have at least %d recordings, stopping." % min_recordings)
         return None
 
+    created_for = patch_args["created_for"]
     if result is not None and token and upload:
         for url, _ in playlist.submit(token, created_for):
             print("Submitted playlist: %s" % url)
 
+    save = patch_args["save"]
     if result is not None and save:
         playlist.save()
         print("playlist saved.")
 
+    echo = patch_args["echo"]
     if result is not None and (echo or not token):
         print()
         playlist.print()


### PR DESCRIPTION
Accept the patch object in generate playlist and move discover_patches out of generate_playlist into the cli command. These changes should make it easier to use troi as a library while still retaining all existing functionality when used as a cli.