### PR TITLE
Prototype click removal from core

### DIFF
--- a/troi/cli.py
+++ b/troi/cli.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from troi.utils import discover_patches
-from troi.core import generate_playlist, list_patches, patch_info
+from troi.core import generate_playlist, list_patches, patch_info, convert_patch_to_command
 
 
 @click.group()
@@ -61,8 +61,10 @@ def playlist(patch, debug, echo, save, token, upload, args, created_for, name, d
 
     if args is None:
         args = []
-    context = patch.parse_args.make_context(patchname, list(args))
-    pipelineargs = context.forward(patch.parse_args)
+
+    cmd = convert_patch_to_command(patch)
+    context = cmd.make_context(patchname, list(args))
+    pipelineargs = context.forward(cmd)
 
     patch_args = {
         "echo": echo,

--- a/troi/core.py
+++ b/troi/core.py
@@ -150,16 +150,18 @@ def patch_info(patch):
 
 def convert_patch_to_command(patch):
     """ Convert patch object to dummy click command to parse args and show help """
-    def f(**kwargs):
-        return kwargs
+    def f(**data):
+        return data
 
     f.__doc__ = patch.inputs.__doc__
 
-    for arg in reversed(patch.inputs()):
-        if arg["type"] == "argument":
-            f = click.argument(*arg["args"], **arg["kwargs"])(f)
-        elif arg["type"] == "option":
-            f = click.option(*arg["args"], **arg["kwargs"])(f)
+    for _input in reversed(patch.inputs()):
+        args = _input.get("args", [])
+        kwargs = _input.get("kwargs", {})
+        if _input["type"] == "argument":
+            f = click.argument(*args, **kwargs)(f)
+        elif _input["type"] == "option":
+            f = click.option(*args, **kwargs)(f)
         else:
             click.echo("Patch is invalid, contact patch writer to fix")
 

--- a/troi/core.py
+++ b/troi/core.py
@@ -143,13 +143,19 @@ def patch_info(patch):
         sys.exit(1)
 
     apatch = patches[patch]
+    cmd = convert_patch_to_command(apatch)
+    context = click.Context(cmd, info_name=patch)
+    click.echo(cmd.get_help(context))
 
-    def f():
-        pass
 
-    f.__doc__ = apatch.get_documentation()
+def convert_patch_to_command(patch):
+    """ Convert patch object to dummy click command to parse args and show help """
+    def f(**kwargs):
+        return kwargs
 
-    for arg in reversed(apatch.get_args()):
+    f.__doc__ = patch.get_documentation()
+
+    for arg in reversed(patch.get_args()):
         if arg["type"] == 'argument':
             f = click.argument(*arg["args"], **arg["kwargs"])(f)
         elif arg["type"] == 'option':
@@ -157,7 +163,4 @@ def patch_info(patch):
         else:
             click.echo("Patch is invalid, contact patch writer to fix")
 
-    f = click.command(no_args_is_help=True)(f)
-
-    context = click.Context(f, info_name=patch)
-    click.echo(f.get_help(context))
+    return click.command(no_args_is_help=True)(f)

--- a/troi/core.py
+++ b/troi/core.py
@@ -153,12 +153,12 @@ def convert_patch_to_command(patch):
     def f(**kwargs):
         return kwargs
 
-    f.__doc__ = patch.get_documentation()
+    f.__doc__ = patch.inputs.__doc__
 
-    for arg in reversed(patch.get_args()):
-        if arg["type"] == 'argument':
+    for arg in reversed(patch.inputs()):
+        if arg["type"] == "argument":
             f = click.argument(*arg["args"], **arg["kwargs"])(f)
-        elif arg["type"] == 'option':
+        elif arg["type"] == "option":
             f = click.option(*arg["args"], **arg["kwargs"])(f)
         else:
             click.echo("Patch is invalid, contact patch writer to fix")

--- a/troi/internal/top_discoveries_for_year.py
+++ b/troi/internal/top_discoveries_for_year.py
@@ -43,7 +43,13 @@ class TopDiscoveries(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a top discoveries playlist for a user.
+
+        \b
+        USER_NAME: is a MusicBrainz username that has an account on ListenBrainz.
+        """
         return [
             {
                 "type": "argument",
@@ -51,15 +57,6 @@ class TopDiscoveries(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a top discoveries playlist for a user.
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        """
 
     @staticmethod
     def inputs():

--- a/troi/internal/top_discoveries_for_year.py
+++ b/troi/internal/top_discoveries_for_year.py
@@ -50,17 +50,7 @@ class TopDiscoveries(troi.patch.Patch):
         \b
         USER_NAME: is a MusicBrainz username that has an account on ListenBrainz.
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            }
-        ]
-
-    @staticmethod
-    def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False }]
+        return [{"type": "argument", "args": ["user_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_discoveries_for_year.py
+++ b/troi/internal/top_discoveries_for_year.py
@@ -1,22 +1,13 @@
 from datetime import datetime
-import random
-import requests
 
-import click
-
-from troi import Element, Artist, Recording, Playlist, PipelineError
-import troi.listenbrainz.recs
-from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
 import troi.filters
-import troi.sorts
-from troi.playlist import PlaylistShuffleElement, PlaylistRedundancyReducerElement
+import troi.listenbrainz.recs
 import troi.musicbrainz.recording_lookup
 import troi.musicbrainz.year_lookup
-
-
-@click.group()
-def cli():
-    pass
+import troi.sorts
+from troi import Recording
+from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
+from troi.playlist import PlaylistShuffleElement, PlaylistRedundancyReducerElement
 
 
 class TopDiscoveries(troi.patch.Patch):
@@ -52,17 +43,23 @@ class TopDiscoveries(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a top discoveries playlist for a user.
 
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
-
-        return kwargs
 
     @staticmethod
     def inputs():

--- a/troi/internal/top_missed_recordings_for_year.py
+++ b/troi/internal/top_missed_recordings_for_year.py
@@ -42,7 +42,13 @@ class TopMissedTracksPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a top missed tracks playlists for a given user.
+
+        \b
+        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
+        """
         return [
             {
                 "type": "argument",
@@ -50,19 +56,6 @@ class TopMissedTracksPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a top missed tracks playlists for a given user.
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        """
-
-    @staticmethod
-    def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False }]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_missed_recordings_for_year.py
+++ b/troi/internal/top_missed_recordings_for_year.py
@@ -1,19 +1,9 @@
-from datetime import datetime 
-from collections import defaultdict
-from urllib.parse import quote
-import requests
-
-import click
+from datetime import datetime
 
 import troi
-from troi import Element, Artist, Recording, Playlist, PipelineError
+from troi import Recording
 from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
 from troi.playlist import PlaylistShuffleElement, PlaylistRedundancyReducerElement
-
-
-@click.group()
-def cli():
-    pass
 
 
 class TopMissedTracksPatch(troi.patch.Patch):
@@ -52,17 +42,23 @@ class TopMissedTracksPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a top missed tracks playlists for a given user.
 
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
-
-        return kwargs
 
     @staticmethod
     def inputs():

--- a/troi/internal/top_missed_recordings_for_year.py
+++ b/troi/internal/top_missed_recordings_for_year.py
@@ -49,13 +49,7 @@ class TopMissedTracksPatch(troi.patch.Patch):
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            }
-        ]
+        return [{"type": "argument", "args": ["user_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/internal/top_new_recordings_you_listened_to_for_year.py
@@ -47,13 +47,7 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            }
-        ]
+        return [{"type": "argument", "args": ["user_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/internal/top_new_recordings_you_listened_to_for_year.py
@@ -39,7 +39,14 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a playlist that contains a mix of tracks released this year that you've
+        listened to.
+
+        \b
+        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
+        """
         return [
             {
                 "type": "argument",
@@ -47,20 +54,6 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a playlist that contains a mix of tracks released this year that you've
-        listened to.
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        """
-
-    @staticmethod
-    def inputs():
-        return [{"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_new_recordings_you_listened_to_for_year.py
+++ b/troi/internal/top_new_recordings_you_listened_to_for_year.py
@@ -1,22 +1,13 @@
-from datetime import datetime 
-from collections import defaultdict
-import requests
+from datetime import datetime
 
-import click
-
-from troi import Element, Artist, Recording, Playlist, PipelineError
-import troi.listenbrainz.stats
 import troi.filters
-import troi.sorts
-from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
-from troi.playlist import PlaylistShuffleElement, PlaylistRedundancyReducerElement
+import troi.listenbrainz.stats
 import troi.musicbrainz.recording_lookup
 import troi.musicbrainz.year_lookup
-
-
-@click.group()
-def cli():
-    pass
+import troi.sorts
+from troi import Recording
+from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
+from troi.playlist import PlaylistShuffleElement, PlaylistRedundancyReducerElement
 
 
 class TopTracksYouListenedToPatch(troi.patch.Patch):
@@ -48,10 +39,18 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a playlist that contains a mix of tracks released this year that you've
         listened to.
 
@@ -59,11 +58,9 @@ class TopTracksYouListenedToPatch(troi.patch.Patch):
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False }]
+        return [{"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_recordings_for_year.py
+++ b/troi/internal/top_recordings_for_year.py
@@ -48,13 +48,7 @@ class TopTracksYearPatch(troi.patch.Patch):
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            }
-        ]
+        return [{"type": "argument", "args": ["user_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_recordings_for_year.py
+++ b/troi/internal/top_recordings_for_year.py
@@ -41,21 +41,27 @@ class TopTracksYearPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a year in review playlist.
 
         \b
         USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False }]
+        return [{"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_recordings_for_year.py
+++ b/troi/internal/top_recordings_for_year.py
@@ -41,7 +41,13 @@ class TopTracksYearPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a year in review playlist.
+
+        \b
+        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
+        """
         return [
             {
                 "type": "argument",
@@ -49,19 +55,6 @@ class TopTracksYearPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a year in review playlist.
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        """
-
-    @staticmethod
-    def inputs():
-        return [{"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_sitewide_recordings_for_year.py
+++ b/troi/internal/top_sitewide_recordings_for_year.py
@@ -1,22 +1,12 @@
-from datetime import datetime 
-from collections import defaultdict
-from urllib.parse import quote
-import requests
+from datetime import datetime
 
-import click
-
-from troi import Element, Artist, Recording, Playlist, PipelineError
+from troi import Recording
 import troi.listenbrainz.stats
 import troi.filters
 import troi.sorts
 import troi.musicbrainz.recording_lookup
 import troi.musicbrainz.mbid_reader
 import troi.playlist
-
-
-@click.group()
-def cli():
-    pass
 
 
 class TopSitewideRecordingsPatch(troi.patch.Patch):
@@ -41,21 +31,27 @@ class TopSitewideRecordingsPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('file_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["file_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate the ListenBrainz site wide top recordings for year playlist.
 
         \b
         FILE_NAME: The filename that contains the recording_mbids for this playlist.
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "file_name", "desc": "Recoding MBID file", "optional": False }]
+        return [{"type": str, "name": "file_name", "desc": "Recoding MBID file", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/internal/top_sitewide_recordings_for_year.py
+++ b/troi/internal/top_sitewide_recordings_for_year.py
@@ -31,7 +31,13 @@ class TopSitewideRecordingsPatch(troi.patch.Patch):
         self.max_num_recordings = max_num_recordings
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate the ListenBrainz site wide top recordings for year playlist.
+
+        \b
+        FILE_NAME: The filename that contains the recording_mbids for this playlist.
+        """
         return [
             {
                 "type": "argument",
@@ -39,19 +45,6 @@ class TopSitewideRecordingsPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate the ListenBrainz site wide top recordings for year playlist.
-
-        \b
-        FILE_NAME: The filename that contains the recording_mbids for this playlist.
-        """
-
-    @staticmethod
-    def inputs():
-        return [{"type": str, "name": "file_name", "desc": "Recoding MBID file", "optional": False}]
 
     @staticmethod
     def outputs():
@@ -77,8 +70,8 @@ class TopSitewideRecordingsPatch(troi.patch.Patch):
         remove_empty = troi.filters.EmptyRecordingFilterElement()
         remove_empty.set_sources(rec_lookup)
 
-        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year),
-                                                      self.DESC % (year),
+        pl_maker = troi.playlist.PlaylistMakerElement(self.NAME % (year,),
+                                                      self.DESC % (year,),
                                                       patch_slug=self.slug())
         pl_maker.set_sources(remove_empty)
 

--- a/troi/internal/top_sitewide_recordings_for_year.py
+++ b/troi/internal/top_sitewide_recordings_for_year.py
@@ -38,13 +38,7 @@ class TopSitewideRecordingsPatch(troi.patch.Patch):
         \b
         FILE_NAME: The filename that contains the recording_mbids for this playlist.
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["file_name"],
-                "kwargs": {}
-            }
-        ]
+        return [{"type": "argument", "args": ["file_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -12,13 +12,11 @@ class Patch(ABC):
         logging.basicConfig(level=level)
         self.logger = logging.getLogger(type(self).__name__)
 
-
     def log(self, msg):
         '''
             Log a message with the info log level, which is the default for troi.
         '''
         self.logger.info(msg)
-
 
     def debug(self, msg):
         '''
@@ -26,21 +24,23 @@ class Patch(ABC):
         '''
         self.logger.debug(msg)
 
-
     @staticmethod
     def inputs():
-        '''
-            This function should return a list of dicts that defined the type, name, description and if the 
-            argument is optional. MusicBrainz entities and python base types can all be used. Example:
+        """
+            This function should return a list of dicts that defined the type (argument or option), args,
+            and kwargs to be passed to the click function. MusicBrainz entities and python base types can
+            all be used. The documentation of the method is used as the help returned by the command. Example:
+
             [
                 {
-                    "type" : int,
-                    "name": "num_recordings",
-                    "optional" : True,
-                    "desc" : "number of recorings"
+                    "type" : "argument",
+                    "args": ["num_recordings"],
+                    "kwargs": {
+                        "optional": True
+                    }
                 }
             ]
-        '''
+        """
         return None
 
     @staticmethod

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -27,25 +27,9 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
         END_YEAR is the end year.
         """
         return [
-            {
-                "type": "argument",
-                "args": ["area"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["start_year"],
-                "kwargs": {
-                    "type": int,
-                }
-            },
-            {
-                "type": "argument",
-                "args": ["end_year"],
-                "kwargs": {
-                    "type": int,
-                }
-            }
+            {"type": "argument", "args": ["area"]},
+            {"type": "argument", "args": ["start_year"], "kwargs": {"type": int}},
+            {"type": "argument", "args": ["end_year"], "kwargs": {"type": int}}
         ]
 
     @staticmethod

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -17,7 +17,15 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
         super().__init__(debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a list of random recordings from a given area.
+
+        \b
+        AREA is a MusicBrainz area from which to choose tracks.
+        START_YEAR is the start year.
+        END_YEAR is the end year.
+        """
         return [
             {
                 "type": "argument",
@@ -39,17 +47,6 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
                 }
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a list of random recordings from a given area.
-
-        \b
-        AREA is a MusicBrainz area from which to choose tracks.
-        START_YEAR is the start year.
-        END_YEAR is the end year.
-        """
 
     @staticmethod
     def outputs():

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -1,7 +1,5 @@
 import datetime
 
-import click
-
 from troi import PipelineError, Recording, DEVELOPMENT_SERVER_URL 
 import troi.tools.area_lookup
 import troi.musicbrainz.recording_lookup
@@ -9,11 +7,6 @@ import troi.patch
 import troi.filters
 from troi.playlist import PlaylistRedundancyReducerElement
 from troi.listenbrainz.dataset_fetcher import DataSetFetcherElement
-
-
-@click.group()
-def cli():
-    pass
 
 
 class AreaRandomRecordingsPatch(troi.patch.Patch):
@@ -24,12 +17,32 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
         super().__init__(debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('area')
-    @click.argument('start_year', type=int)
-    @click.argument('end_year', type=int)
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["area"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["start_year"],
+                "kwargs": {
+                    "type": int,
+                }
+            },
+            {
+                "type": "argument",
+                "args": ["end_year"],
+                "kwargs": {
+                    "type": int,
+                }
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a list of random recordings from a given area.
 
         \b
@@ -37,8 +50,6 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
         START_YEAR is the start year.
         END_YEAR is the end year.
         """
-
-        return kwargs
 
     @staticmethod
     def outputs():
@@ -72,7 +83,6 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
                                      json_post_data=[{ 'start_year': start_year,
                                                        'end_year': end_year,
                                                        'area_mbid': area_id }])
-
 
         name = "Random recordings from %s between %d and %d." % (area_name, start_year, end_year)
         pl_maker = troi.playlist.PlaylistMakerElement(name=name, desc=name)

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -36,18 +36,8 @@ class DailyJamsPatch(troi.patch.Patch):
         can be on different dates). Recommended formatting for the date is 'YYYY-MM-DD DAY_OF_WEEK'.
         """
         return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["jam_date"],
-                "kwargs": {
-                    "required": False,
-                }
-            }
+            {"type": "argument", "args": ["user_name"]},
+            {"type": "argument", "args": ["jam_date"], "kwargs": {"required": False}}
         ]
 
     @staticmethod

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -26,7 +26,15 @@ class DailyJamsPatch(troi.patch.Patch):
         self.recent_listens_lookup = None
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a daily playlist from the ListenBrainz recommended recordings.
+
+        \b
+        USER_NAME is a MusicBrainz user name that has an account on ListenBrainz.
+        JAM_DATE is the date for which the jam is created (this is needed to account for the fact different timezones
+        can be on different dates). Recommended formatting for the date is 'YYYY-MM-DD DAY_OF_WEEK'.
+        """
         return [
             {
                 "type": "argument",
@@ -41,17 +49,6 @@ class DailyJamsPatch(troi.patch.Patch):
                 }
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a daily playlist from the ListenBrainz recommended recordings.
-
-        \b
-        USER_NAME is a MusicBrainz user name that has an account on ListenBrainz.
-        JAM_DATE is the date for which the jam is created (this is needed to account for the fact different timezones
-        can be on different dates). Recommended formatting for the date is 'YYYY-MM-DD DAY_OF_WEEK'.
-        """
 
     @staticmethod
     def outputs():

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -1,21 +1,13 @@
 from datetime import datetime
 
-import click
-
+import troi.filters
+import troi.listenbrainz.feedback
+import troi.listenbrainz.listens
+import troi.listenbrainz.recs
+import troi.musicbrainz.recording_lookup
 from troi import Playlist
 from troi.musicbrainz.recording import RecordingListElement
 from troi.playlist import PlaylistRedundancyReducerElement, PlaylistMakerElement, PlaylistShuffleElement
-import troi.listenbrainz.recs
-import troi.listenbrainz.listens
-import troi.listenbrainz.feedback
-import troi.filters
-import troi.musicbrainz.recording_lookup
-
-
-@click.group()
-def cli():
-    pass
-
 
 DAYS_OF_RECENT_LISTENS_TO_EXCLUDE = 60  # Exclude tracks listened in last X days from the daily jams playlist
 DAILY_JAMS_MIN_RECORDINGS = 25  # the minimum number of recordings we aspire to have in a daily jam, this is not a hard limit

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -34,11 +34,25 @@ class DailyJamsPatch(troi.patch.Patch):
         self.recent_listens_lookup = None
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    @click.argument('jam_date', required=False)
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["jam_date"],
+                "kwargs": {
+                    "required": False,
+                }
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a daily playlist from the ListenBrainz recommended recordings.
 
         \b
@@ -46,8 +60,6 @@ class DailyJamsPatch(troi.patch.Patch):
         JAM_DATE is the date for which the jam is created (this is needed to account for the fact different timezones
         can be on different dates). Recommended formatting for the date is 'YYYY-MM-DD DAY_OF_WEEK'.
         """
-
-        return kwargs
 
     @staticmethod
     def outputs():

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -1,23 +1,30 @@
-import click
-
 from troi import Playlist
 from troi.playlist import PlaylistFromJSPFElement
 import troi.musicbrainz.recording_lookup
 
 
-@click.group()
-def cli():
-    pass
-
-
 class TransferPlaylistPatch(troi.patch.Patch):
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument("mbid")
-    @click.argument("read_only_token", required=False)
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["mbid"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["read_only_token"],
+                "kwargs": {
+                    "required": False,
+                }
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         A dummy patch that retrieves an existing playlist from ListenBrainz.
 
         \b
@@ -26,7 +33,6 @@ class TransferPlaylistPatch(troi.patch.Patch):
         fallback to TOKEN. Both arguments take the same value but specifying TOKEN may also upload the playlist
         to LB again which is many times not desirable.
         """
-        return kwargs
 
     @staticmethod
     def outputs():

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -17,18 +17,8 @@ class TransferPlaylistPatch(troi.patch.Patch):
         to LB again which is many times not desirable.
         """
         return [
-            {
-                "type": "argument",
-                "args": ["mbid"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["read_only_token"],
-                "kwargs": {
-                    "required": False,
-                }
-            }
+            {"type": "argument", "args": ["mbid"]},
+            {"type": "argument", "args": ["read_only_token"], "kwargs": {"required": False}}
         ]
 
     @staticmethod

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -6,7 +6,16 @@ import troi.musicbrainz.recording_lookup
 class TransferPlaylistPatch(troi.patch.Patch):
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        A dummy patch that retrieves an existing playlist from ListenBrainz.
+
+        \b
+        MBID is the playlist mbid to save again.
+        READ_ONLY_TOKEN is the listenbrainz auth token to retrieve the playlist if its private. If not specified,
+        fallback to TOKEN. Both arguments take the same value but specifying TOKEN may also upload the playlist
+        to LB again which is many times not desirable.
+        """
         return [
             {
                 "type": "argument",
@@ -21,18 +30,6 @@ class TransferPlaylistPatch(troi.patch.Patch):
                 }
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        A dummy patch that retrieves an existing playlist from ListenBrainz.
-
-        \b
-        MBID is the playlist mbid to save again.
-        READ_ONLY_TOKEN is the listenbrainz auth token to retrieve the playlist if its private. If not specified,
-        fallback to TOKEN. Both arguments take the same value but specifying TOKEN may also upload the playlist
-        to LB again which is many times not desirable.
-        """
 
     @staticmethod
     def outputs():

--- a/troi/patches/playlist_from_mbids.py
+++ b/troi/patches/playlist_from_mbids.py
@@ -13,7 +13,13 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Make a playlist from a file containing one MBID per line.
+
+        \b
+        FILE_NAME: filename that contains MBIDS
+        """
         return [
             {
                 "type": "argument",
@@ -21,19 +27,6 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Make a playlist from a file containing one MBID per line.
-
-        \b
-        FILE_NAME: filename that contains MBIDS
-        """
-
-    @staticmethod
-    def inputs():
-        return [{"type": str, "name": "file_name", "desc": "MBID filename", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/patches/playlist_from_mbids.py
+++ b/troi/patches/playlist_from_mbids.py
@@ -20,13 +20,7 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
         \b
         FILE_NAME: filename that contains MBIDS
         """
-        return [
-            {
-                "type": "argument",
-                "args": ["file_name"],
-                "kwargs": {}
-            }
-        ]
+        return [{"type": "argument", "args": ["file_name"]}]
 
     @staticmethod
     def outputs():

--- a/troi/patches/playlist_from_mbids.py
+++ b/troi/patches/playlist_from_mbids.py
@@ -1,20 +1,8 @@
-from datetime import datetime 
-from collections import defaultdict
-from urllib.parse import quote
-import requests
-
-import click
-
 import troi
-from troi import Element, Artist, Recording, Playlist, PipelineError
+from troi import Recording
 from troi.musicbrainz.mbid_reader import MBIDReaderElement
 from troi.musicbrainz.recording_lookup import RecordingLookupElement
 from troi.playlist import PlaylistMakerElement
-
-
-@click.group()
-def cli():
-    pass
 
 
 class PlaylistFromMBIDsPatch(troi.patch.Patch):
@@ -25,21 +13,27 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('file_name')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["file_name"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Make a playlist from a file containing one MBID per line.
 
         \b
         FILE_NAME: filename that contains MBIDS
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "file_name", "desc": "MBID filename", "optional": False }]
+        return [{"type": str, "name": "file_name", "desc": "MBID filename", "optional": False}]
 
     @staticmethod
     def outputs():

--- a/troi/patches/recs_to_playlist.py
+++ b/troi/patches/recs_to_playlist.py
@@ -71,16 +71,8 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
         TYPE: is The type of daily jam. Must be 'top' or 'similar' or 'raw'.
         """
         return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["type"],
-                "kwargs": {}
-            }
+            {"type": "argument", "args": ["user_name"]},
+            {"type": "argument", "args": ["type"]}
         ]
 
     @staticmethod

--- a/troi/patches/recs_to_playlist.py
+++ b/troi/patches/recs_to_playlist.py
@@ -62,7 +62,14 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Save the current recommended tracks for a given user and type (top or similar).
+
+        \b
+        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
+        TYPE: is The type of daily jam. Must be 'top' or 'similar' or 'raw'.
+        """
         return [
             {
                 "type": "argument",
@@ -74,23 +81,6 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
                 "args": ["type"],
                 "kwargs": {}
             }
-        ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Save the current recommended tracks for a given user and type (top or similar).
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        TYPE: is The type of daily jam. Must be 'top' or 'similar' or 'raw'.
-        """
-
-    @staticmethod
-    def inputs():
-        return [
-            {"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False},
-            {"type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False}
         ]
 
     @staticmethod

--- a/troi/patches/recs_to_playlist.py
+++ b/troi/patches/recs_to_playlist.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-import random
-
-import click
-
 from troi import Element, Recording, Playlist, PipelineError
 import troi.listenbrainz.recs
 import troi.playlist
@@ -10,11 +5,6 @@ import troi.filters
 import troi.sorts
 import troi.musicbrainz.recording_lookup
 import troi.musicbrainz.mbid_mapping
-
-
-@click.group()
-def cli():
-    pass
 
 
 class RecsPlaylistMakerElement(Element):
@@ -72,11 +62,23 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    @click.argument('type')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["type"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Save the current recommended tracks for a given user and type (top or similar).
 
         \b
@@ -84,12 +86,12 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
         TYPE: is The type of daily jam. Must be 'top' or 'similar' or 'raw'.
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False },
-                { "type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False }]
+        return [
+            {"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False},
+            {"type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False}
+        ]
 
     @staticmethod
     def outputs():

--- a/troi/patches/weekly_flashback_jams.py
+++ b/troi/patches/weekly_flashback_jams.py
@@ -1,20 +1,14 @@
-from collections import defaultdict
 import random
+from collections import defaultdict
 
-import click
-
-from troi import Element, Recording, Playlist, PipelineError
-import troi.listenbrainz.recs
-import troi.playlist
 import troi.filters
-import troi.sorts
-import troi.musicbrainz.recording_lookup
+import troi.listenbrainz.recs
 import troi.musicbrainz.mbid_mapping
+import troi.musicbrainz.recording_lookup
+import troi.playlist
+import troi.sorts
+from troi import Element, Recording, Playlist, PipelineError
 
-
-@click.group()
-def cli():
-    pass
 
 class DecadePlaylistSplitterElement(Element):
     '''
@@ -73,11 +67,23 @@ class WeeklyFlashbackJams(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('user_name')
-    @click.argument('type')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["user_name"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["type"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate weekly flashback playlists from the ListenBrainz recommended recordings.
 
         \b
@@ -86,12 +92,12 @@ class WeeklyFlashbackJams(troi.patch.Patch):
         TOKEN: is the user token from the LB user into whose account you wish to post this playlist
         """
 
-        return kwargs
-
     @staticmethod
     def inputs():
-        return [{ "type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False },
-                { "type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False }]
+        return [
+            {"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False},
+            {"type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False}
+        ]
 
     @staticmethod
     def outputs():

--- a/troi/patches/weekly_flashback_jams.py
+++ b/troi/patches/weekly_flashback_jams.py
@@ -67,7 +67,15 @@ class WeeklyFlashbackJams(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate weekly flashback playlists from the ListenBrainz recommended recordings.
+
+        \b
+        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
+        TYPE: is The type of daily jam. Must be 'top' or 'similar'.
+        TOKEN: is the user token from the LB user into whose account you wish to post this playlist
+        """
         return [
             {
                 "type": "argument",
@@ -79,24 +87,6 @@ class WeeklyFlashbackJams(troi.patch.Patch):
                 "args": ["type"],
                 "kwargs": {}
             }
-        ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate weekly flashback playlists from the ListenBrainz recommended recordings.
-
-        \b
-        USER_NAME: is a MusicBrainz user name that has an account on ListenBrainz.
-        TYPE: is The type of daily jam. Must be 'top' or 'similar'.
-        TOKEN: is the user token from the LB user into whose account you wish to post this playlist
-        """
-
-    @staticmethod
-    def inputs():
-        return [
-            {"type": str, "name": "user_name", "desc": "ListenBrainz user name", "optional": False},
-            {"type": str, "name": "type", "desc": "The type of daily jam. Must be 'top' or 'similar'.", "optional": False}
         ]
 
     @staticmethod

--- a/troi/patches/weekly_flashback_jams.py
+++ b/troi/patches/weekly_flashback_jams.py
@@ -77,16 +77,8 @@ class WeeklyFlashbackJams(troi.patch.Patch):
         TOKEN: is the user token from the LB user into whose account you wish to post this playlist
         """
         return [
-            {
-                "type": "argument",
-                "args": ["user_name"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["type"],
-                "kwargs": {}
-            }
+            {"type": "argument", "args": ["user_name"]},
+            {"type": "argument", "args": ["type"]}
         ]
 
     @staticmethod

--- a/troi/patches/world_trip.py
+++ b/troi/patches/world_trip.py
@@ -135,16 +135,8 @@ class WorldTripPatch(troi.patch.Patch):
         SORT: Must be longitude or latitude
         """
         return [
-            {
-                "type": "argument",
-                "args": ["continent"],
-                "kwargs": {}
-            },
-            {
-                "type": "argument",
-                "args": ["sort"],
-                "kwargs": {}
-            }
+            {"type": "argument", "args": ["continent"]},
+            {"type": "argument", "args": ["sort"]}
         ]
 
     @staticmethod

--- a/troi/patches/world_trip.py
+++ b/troi/patches/world_trip.py
@@ -1,18 +1,12 @@
-from collections import defaultdict 
-from operator import attrgetter
+from collections import defaultdict
 from urllib.parse import quote
 
-import click
-import requests
 import countryinfo
+import requests
 
-from troi import Element, Artist, Recording, Playlist, PipelineError, DEVELOPMENT_SERVER_URL
 import troi.patch
+from troi import Element, Artist, Recording, Playlist, PipelineError, DEVELOPMENT_SERVER_URL
 
-
-@click.group()
-def cli():
-    pass
 
 def recording_from_row(row):
     if row['recording_mbid'] is None:
@@ -132,19 +126,29 @@ class WorldTripPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    @cli.command(no_args_is_help=True)
-    @click.argument('continent')
-    @click.argument('sort')
-    def parse_args(**kwargs):
-        """
+    def get_args():
+        return [
+            {
+                "type": "argument",
+                "args": ["continent"],
+                "kwargs": {}
+            },
+            {
+                "type": "argument",
+                "args": ["sort"],
+                "kwargs": {}
+            }
+        ]
+
+    @staticmethod
+    def get_documentation():
+        return """
         Generate a playlist that picks tracks for each country in a continent.
 
         \b
         CONTINENT: A name of a continent, all lower case.
         SORT: Must be longitude or latitude
         """
-
-        return kwargs
 
     @staticmethod
     def inputs():

--- a/troi/patches/world_trip.py
+++ b/troi/patches/world_trip.py
@@ -126,7 +126,14 @@ class WorldTripPatch(troi.patch.Patch):
         troi.patch.Patch.__init__(self, debug)
 
     @staticmethod
-    def get_args():
+    def inputs():
+        """
+        Generate a playlist that picks tracks for each country in a continent.
+
+        \b
+        CONTINENT: A name of a continent, all lower case.
+        SORT: Must be longitude or latitude
+        """
         return [
             {
                 "type": "argument",
@@ -139,21 +146,6 @@ class WorldTripPatch(troi.patch.Patch):
                 "kwargs": {}
             }
         ]
-
-    @staticmethod
-    def get_documentation():
-        return """
-        Generate a playlist that picks tracks for each country in a continent.
-
-        \b
-        CONTINENT: A name of a continent, all lower case.
-        SORT: Must be longitude or latitude
-        """
-
-    @staticmethod
-    def inputs():
-        return [{ "type": str, "name": "continent", "desc": "continent to generate playlist for", "optional": False },
-                { "type": str, "name": "sort", "desc": "Sort by latitude (north->south), longitude (west->east)", "optional": False }]
 
     @staticmethod
     def outputs():


### PR DESCRIPTION
To make it simpler to use troi as a library, we intend to remove click from the core lib. Click seemingly doesn't allow adding options/arguments to a command at runtime. So here's some cursed workaround it. I have only ported one patch for now so that we can discuss if the approach is fine.