### PR TITLE
Add element to load a playlist from LB

### DIFF
--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -261,7 +261,8 @@ class Playlist(Entity):
         do that and didn't provide a different filename.
     """
     def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
-                 year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None):
+                 year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None,
+                 external_urls=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
@@ -270,6 +271,7 @@ class Playlist(Entity):
         self.description = description
         self.patch_slug = patch_slug
         self.user_name = user_name
+        self.external_urls = external_urls
 
     def __str__(self):
         return "<Playlist('%s', %s, %s)>" % (self.name, self.description, self.mbid)
@@ -292,7 +294,6 @@ class User(Entity):
 
     def __str__(self):
         return "<User('%s', %d)>" % (self.user_name, self.user_id or -1)
-
 
 
 class PipelineError(RuntimeError):

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -10,7 +10,7 @@ def cli():
     pass
 
 
-class ResavePatch(troi.patch.Patch):
+class TransferPlaylistPatch(troi.patch.Patch):
 
     @staticmethod
     @cli.command(no_args_is_help=True)
@@ -34,7 +34,7 @@ class ResavePatch(troi.patch.Patch):
 
     @staticmethod
     def slug():
-        return "resave-playlist"
+        return "transfer-playlist"
 
     @staticmethod
     def description():

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -41,8 +41,5 @@ class TransferPlaylistPatch(troi.patch.Patch):
         return "Retrieve a playlist from the ListenBrainz"
 
     def create(self, inputs):
-        token = inputs.get("read_only_token")
-        if not token:
-            token = inputs.get("token")
-        playlist = PlaylistFromJSPFElement(inputs["mbid"], token)
-        return playlist
+        token = inputs.get("read_only_token") or inputs.get("token")
+        return PlaylistFromJSPFElement(inputs["mbid"], token)

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -15,16 +15,17 @@ class ResavePatch(troi.patch.Patch):
     @staticmethod
     @cli.command(no_args_is_help=True)
     @click.argument("mbid")
-    @click.argument("token", required=False)
+    @click.argument("read_only_token", required=False)
     def parse_args(**kwargs):
         """
         A dummy patch that retrieves an existing playlist from ListenBrainz.
 
         \b
         MBID is the playlist mbid to save again.
-        TOKEN is the listenbrainz auth token to retrieve the playlist if its private.
+        READ_ONLY_TOKEN is the listenbrainz auth token to retrieve the playlist if its private. If not specified,
+        fallback to TOKEN. Both arguments take the same value but specifying TOKEN may also upload the playlist
+        to LB again which is many times not desirable.
         """
-
         return kwargs
 
     @staticmethod
@@ -39,9 +40,9 @@ class ResavePatch(troi.patch.Patch):
     def description():
         return "Retrieve a playlist from the ListenBrainz"
 
-    def create(self, inputs, patch_args):
-        token = inputs.get("token")
+    def create(self, inputs):
+        token = inputs.get("read_only_token")
         if not token:
-            token = patch_args.get("token")
+            token = inputs.get("token")
         playlist = PlaylistFromJSPFElement(inputs["mbid"], token)
         return playlist

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -1,0 +1,42 @@
+import click
+
+from troi import Playlist
+from troi.playlist import PlaylistFromJSPFElement
+import troi.musicbrainz.recording_lookup
+
+
+@click.group()
+def cli():
+    pass
+
+
+class ResavePatch(troi.patch.Patch):
+
+    @staticmethod
+    @cli.command(no_args_is_help=True)
+    @click.argument("mbid")
+    def parse_args(**kwargs):
+        """
+        A dummy patch that retrieves an existing playlist from ListenBrainz.
+
+        \b
+        MBID is the playlist mbid to save again.
+        """
+
+        return kwargs
+
+    @staticmethod
+    def outputs():
+        return [Playlist]
+
+    @staticmethod
+    def slug():
+        return "resave-playlist"
+
+    @staticmethod
+    def description():
+        return "Retrieve a playlist from the ListenBrainz"
+
+    def create(self, inputs, patch_args):
+        playlist = PlaylistFromJSPFElement(inputs["mbid"], patch_args.get("token"))
+        return playlist

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -15,12 +15,14 @@ class ResavePatch(troi.patch.Patch):
     @staticmethod
     @cli.command(no_args_is_help=True)
     @click.argument("mbid")
+    @click.argument("token", required=False)
     def parse_args(**kwargs):
         """
         A dummy patch that retrieves an existing playlist from ListenBrainz.
 
         \b
         MBID is the playlist mbid to save again.
+        TOKEN is the listenbrainz auth token to retrieve the playlist if its private.
         """
 
         return kwargs
@@ -38,5 +40,8 @@ class ResavePatch(troi.patch.Patch):
         return "Retrieve a playlist from the ListenBrainz"
 
     def create(self, inputs, patch_args):
-        playlist = PlaylistFromJSPFElement(inputs["mbid"], patch_args.get("token"))
+        token = inputs.get("token")
+        if not token:
+            token = patch_args.get("token")
+        playlist = PlaylistFromJSPFElement(inputs["mbid"], token)
         return playlist

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -390,7 +390,6 @@ class PlaylistBPMSawtoothSortElement(Element):
 
         return sorted_recs
 
-
     def read(self, inputs):
         for playlist in inputs[0]:
             playlist.recordings = self.bpm_sawtooth_sort(playlist.recordings)

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -275,6 +275,11 @@ class PlaylistElement(Element):
             fixup_spotify_playlist(sp, spotify_playlist["id"], mbid_spotify_index, spotify_mbid_index)
             submitted.append((spotify_playlist["external_urls"]["spotify"], spotify_playlist["id"]))
 
+            if playlist.external_urls:
+                playlist.external_urls.append(spotify_playlist["external_urls"]["spotify"])
+            else:
+                playlist.external_urls = [spotify_playlist["external_urls"]["spotify"]]
+
         return submitted
 
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -457,6 +457,4 @@ class PlaylistFromJSPFElement(Element):
         response = requests.get(LISTENBRAINZ_PLAYLIST_FETCH_URL + self.playlist_mbid, headers=headers)
         response.raise_for_status()
         data = response.json()
-
-        playlist = _deserialize_from_jspf(data)
-        return [playlist]
+        return [_deserialize_from_jspf(data)]

--- a/troi/tests/test_playlist.py
+++ b/troi/tests/test_playlist.py
@@ -191,3 +191,5 @@ class TestSpotifySubmission(unittest.TestCase):
                 "spotify:track:4hyVrAsoKKjxAvQjPRt0ai"
             ]
         })
+
+        self.assertEqual(playlist.playlists[0].external_urls, [playlist_url])

--- a/troi/tests/test_utils.py
+++ b/troi/tests/test_utils.py
@@ -16,7 +16,7 @@ class TestPatches(unittest.TestCase):
         assert "playlist-from-mbids" in patches
         assert "world-trip" in patches
         assert "recs-to-playlist" in patches
-        assert "resave-playlist" in patches
+        assert "transfer-playlist" in patches
 
         for p in patches:
             assert issubclass(patches[p], Patch)

--- a/troi/tests/test_utils.py
+++ b/troi/tests/test_utils.py
@@ -9,13 +9,14 @@ class TestPatches(unittest.TestCase):
     def test_discover_patches(self):
         patches = discover_patches()
 
-        assert len(patches) == 6
+        assert len(patches) == 7
         assert "daily-jams" in patches
         assert "area-random-recordings" in patches
         assert "weekly-flashback-jams" in patches
         assert "playlist-from-mbids" in patches
         assert "world-trip" in patches
         assert "recs-to-playlist" in patches
+        assert "resave-playlist" in patches
 
         for p in patches:
             assert issubclass(patches[p], Patch)


### PR DESCRIPTION
Add a method to de-serialize JSPF playlist to a `troi.Playlist` entity. Also, added a dummy patch for now but we may not want to put that in LB instead of troi or maybe go entirely some other way.