### PR TITLE
Add RecentListensTimestampLookup element

### DIFF
--- a/troi/listenbrainz/listens.py
+++ b/troi/listenbrainz/listens.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+import requests
+
+from troi import Element, Recording
+
+
+class RecentListensTimestampLookup(Element):
+    """ Element to look up the time when a user last listened given recordings in past X days """
+
+    def __init__(self, user_name, days: int):
+        super().__init__()
+        self.user_name = user_name
+        self.days = days
+
+    @staticmethod
+    def inputs():
+        return [Recording]
+
+    @staticmethod
+    def outputs():
+        return [Recording]
+
+    @staticmethod
+    def get_recording_mbid(listen):
+        """ Retrieve recording_mbid of the listen, prefer user submitted mbid to mbid mapping one """
+        additional_info = listen["track_metadata"]["additional_info"]
+        mbid = additional_info.get("recording_mbid")
+
+        if mbid:
+            return mbid
+
+        mbid_mapping = listen["track_metadata"].get("mbid_mapping")
+        if mbid_mapping:
+            return mbid_mapping.get("recording_mbid")
+
+    def _fetch_recent_listens_index(self):
+        """ Return an index of recording mbids as key and the latest listened_at time of the corresponding
+        recording as values.
+        """
+        index = defaultdict(int)
+
+        min_dt = datetime.now() + timedelta(days=-self.days)
+        min_ts = int(min_dt.timestamp())
+        while True:
+            response = requests.get(
+                f"https://api.listenbrainz.org/1/user/{self.user_name}/listens",
+                params={"min_ts": min_ts, "count": 100}
+            )
+            response.raise_for_status()
+            data = response.json()["payload"]
+            if len(data["listens"]) == 0:
+                break
+
+            for listen in data["listens"]:
+                listened_at = listen["listened_at"]
+                mbid = self.get_recording_mbid(listen)
+
+                if mbid:
+                    index[mbid] = max(index[mbid], listened_at)
+
+            min_ts = data["listens"][0]["listened_at"]
+
+        return index
+
+    def read(self, inputs):
+        recordings = inputs[0]
+        if not recordings:
+            return []
+
+        index = self._fetch_recent_listens_index()
+
+        for r in recordings:
+            if r.mbid not in index:
+                continue
+
+            ts = index[r.mbid]
+            latest_listened_at = datetime.fromtimestamp(ts).replace(tzinfo=None)
+
+            if r.listenbrainz is not None:
+                r.listenbrainz["latest_listened_at"] = latest_listened_at
+            else:
+                r.listenbrainz = {"latest_listened_at": latest_listened_at}
+
+        return recordings

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -15,6 +15,9 @@ def cli():
     pass
 
 
+DAYS_OF_RECENT_LISTENS_TO_EXCLUDE = 14  # Exclude tracks listened in last X days from the daily jams playlist
+
+
 class DailyJamsPatch(troi.patch.Patch):
     """
         Taken a list of Recordings, break them into 7 roughly equal chunks and return
@@ -64,7 +67,7 @@ class DailyJamsPatch(troi.patch.Patch):
         recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2)
         recent_listens_lookup.set_sources(raw_recs_lookup)
 
-        latest_filter = troi.filters.LatestListenedAtFilterElement(14)
+        latest_filter = troi.filters.LatestListenedAtFilterElement(DAYS_OF_RECENT_LISTENS_TO_EXCLUDE)
         latest_filter.set_sources(recent_listens_lookup)
 
         pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date),

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -1,12 +1,11 @@
-from datetime import datetime, timedelta
-from itertools import zip_longest
-import random
+from datetime import datetime
 
 import click
 
-from troi import PipelineError, Recording, Playlist
+from troi import Playlist
 from troi.playlist import PlaylistRedundancyReducerElement, PlaylistMakerElement, PlaylistShuffleElement
 import troi.listenbrainz.recs
+import troi.listenbrainz.listens
 import troi.filters
 import troi.musicbrainz.recording_lookup
 
@@ -62,8 +61,11 @@ class DailyJamsPatch(troi.patch.Patch):
         raw_recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
         raw_recs_lookup.set_sources(raw_recs)
 
+        recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2)
+        recent_listens_lookup.set_sources(raw_recs_lookup)
+
         latest_filter = troi.filters.LatestListenedAtFilterElement(14)
-        latest_filter.set_sources(raw_recs_lookup)
+        latest_filter.set_sources(recent_listens_lookup)
 
         pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date),
                                         desc="Daily jams playlist!",


### PR DESCRIPTION
We generate daily jams based on user's timezone in ListenBrainz. In many cases, these jams will get generated before yesterday's listens get imported in the Spark cluster. As a result the latest_listened_at timestamp, of the recommendations can be out of date. To fix this, retrieve all listens of the user from last 2 days and augument the latest_listened_at value of the recordings with those.