### PR TITLE
Add more tracks to daily jams if needed

### DIFF
--- a/troi/listenbrainz/listens.py
+++ b/troi/listenbrainz/listens.py
@@ -7,12 +7,15 @@ from troi import Element, Recording
 
 
 class RecentListensTimestampLookup(Element):
-    """ Element to look up the time when a user last listened given recordings in past X days """
+    """ Element to look up the time when a user last listened given recordings in past X days. Note that the
+    element is stateful and caches the recent listens lookup results.
+    """
 
     def __init__(self, user_name, days: int):
         super().__init__()
         self.user_name = user_name
         self.days = days
+        self.index = None
 
     @staticmethod
     def inputs():
@@ -69,13 +72,14 @@ class RecentListensTimestampLookup(Element):
         if not recordings:
             return []
 
-        index = self._fetch_recent_listens_index()
+        if self.index is None:
+            self.index = self._fetch_recent_listens_index()
 
         for r in recordings:
-            if r.mbid not in index:
+            if r.mbid not in self.index:
                 continue
 
-            ts = index[r.mbid]
+            ts = self.index[r.mbid]
             latest_listened_at = datetime.fromtimestamp(ts).replace(tzinfo=None)
 
             if r.listenbrainz is not None:

--- a/troi/musicbrainz/recording.py
+++ b/troi/musicbrainz/recording.py
@@ -1,0 +1,20 @@
+from troi import Element, Recording
+
+
+class RecordingListElement(Element):
+    """ This element is used to pass a provided list of Recordings into the pipeline. """
+
+    def __init__(self, recordings):
+        super().__init__()
+        self.recordings = recordings
+
+    @staticmethod
+    def inputs():
+        return []
+
+    @staticmethod
+    def outputs():
+        return [Recording]
+
+    def read(self, inputs):
+        return self.recordings

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -69,7 +69,7 @@ class RecordingLookupElement(Element):
                 r.artist = a
             else:
                 r.artist.name = row['artist_credit_name']
-                r.artist.mbids = row.get('[artist_credit_mbids]', []),
+                r.artist.mbids = row.get('[artist_credit_mbids]', [])
                 r.artist.artist_credit_id = row['artist_credit_id']
 
             r.name = row['recording_name']

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import click
 
 from troi import Playlist
+from troi.musicbrainz.recording import RecordingListElement
 from troi.playlist import PlaylistRedundancyReducerElement, PlaylistMakerElement, PlaylistShuffleElement
 import troi.listenbrainz.recs
 import troi.listenbrainz.listens
@@ -16,6 +17,7 @@ def cli():
 
 
 DAYS_OF_RECENT_LISTENS_TO_EXCLUDE = 14  # Exclude tracks listened in last X days from the daily jams playlist
+DAILY_JAMS_MIN_RECORDINGS = 25  # the minimum number of recordings we aspire to have in a daily jam, this is not a hard limit
 
 
 class DailyJamsPatch(troi.patch.Patch):
@@ -52,18 +54,9 @@ class DailyJamsPatch(troi.patch.Patch):
     def description():
         return "Generate a daily playlist from the ListenBrainz recommended recordings."
 
-    def create(self, inputs):
-        user_name = inputs['user_name']
-        jam_date = inputs.get('jam_date')
-        if jam_date is None:
-            jam_date = datetime.utcnow().strftime("%Y-%m-%d %a")
-
-        raw_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name=user_name,
-                                                                              artist_type="raw",
-                                                                              count=100)
-
+    def apply_filters(self, user_name, element):
         deduped_raw_recs = troi.filters.DuplicateRecordingMBIDFilterElement()
-        deduped_raw_recs.set_sources(raw_recs)
+        deduped_raw_recs.set_sources(element)
 
         raw_recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
         raw_recs_lookup.set_sources(deduped_raw_recs)
@@ -74,10 +67,50 @@ class DailyJamsPatch(troi.patch.Patch):
         latest_filter = troi.filters.LatestListenedAtFilterElement(DAYS_OF_RECENT_LISTENS_TO_EXCLUDE)
         latest_filter.set_sources(recent_listens_lookup)
 
+        return latest_filter
+
+    def check_and_add_more_recordings(self, user_name, recordings):
+        # get the list of recordings we have so far, users who regularly listen to daily jams will have
+        # most of their tracks get filtered out because the recs don't change a lot on daily basis. so
+        # if there is a shortfall of tracks, move on the next 100 recommendations of the user. we could
+        # fetch top 200 directly in first place but then there would be an equal chance of recommending
+        # someone from their 101-200 range as from 1-100. we don't want that, we want to prefer the top
+        # 100 over the next 100. so only ask for more recommendations if there is a shortfall.
+        if len(recordings) < DAILY_JAMS_MIN_RECORDINGS:
+            more_raw_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(
+                user_name=user_name,
+                artist_type="raw",
+                count=100,
+                offset=100
+            )
+            further_recs = more_raw_recs.generate()
+            recordings.extend(further_recs)
+
+            all_recs = RecordingListElement(recordings)
+            return self.apply_filters(user_name, all_recs)
+        else:
+            return RecordingListElement(recordings)
+
+    def create(self, inputs):
+        user_name = inputs['user_name']
+        jam_date = inputs.get('jam_date')
+        if jam_date is None:
+            jam_date = datetime.utcnow().strftime("%Y-%m-%d %a")
+
+        raw_recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(
+            user_name=user_name,
+            artist_type="raw",
+            count=100
+        )
+        filtered_raw_recs = self.apply_filters(user_name, raw_recs)
+
+        recordings = filtered_raw_recs.generate()
+        recordings_element = self.check_and_add_more_recordings(user_name, recordings)
+
         pl_maker = PlaylistMakerElement(name="Daily Jams for %s, %s" % (user_name, jam_date),
                                         desc="Daily jams playlist!",
                                         patch_slug=self.slug())
-        pl_maker.set_sources(latest_filter)
+        pl_maker.set_sources(recordings_element)
 
         reducer = PlaylistRedundancyReducerElement()
         reducer.set_sources(pl_maker)


### PR DESCRIPTION
Users who regularly listen to daily jams start to see very less tracks in their playlists. Currently, we consider top 100 raw recs as the source of daily jams playlists and filter out any tracks listened in the past 14 days. Since recommendations don't change a lot on daily basis, most of the tracks get filtered.

To tackle this situation, we add the next 100 raw recommendations of the user to the source. Note that we do not fetch top 200 directly because that would mean an equal chance of recommending a track from 101-200 range as a track from 1-100. We don't want that, we want to prefer the top 100 over the next 100. Hence, only ask for more recordings if there is a shortfall.