### PR TITLE
Use additional_metadata property instead of algorithm_metadata

### DIFF
--- a/troi/internal/yim_patch_runner.py
+++ b/troi/internal/yim_patch_runner.py
@@ -34,7 +34,7 @@ class YIMSubmitterElement(Element):
             return None
 
         slug = inputs[0][0].patch_slug
-        metadata = { "source_patch": slug }
+        metadata = {"algorithm_metadata": {"source_patch": slug}}
         with open("%s-playlists.json" % slug, "w") as f:
             print("YIMSubmitter:")
             for playlist in inputs[0]:
@@ -48,7 +48,7 @@ class YIMSubmitterElement(Element):
                 # This is hacky and should be moved to playlist
                 playlist_element = PlaylistElement()
                 playlist_element.playlists = [ playlist ]
-                playlist_element.save(track_count=5, algorithm_metadata=metadata, file_obj=f)
+                playlist_element.save(track_count=5, additional_metadata=metadata, file_obj=f)
                 f.write("\n")
 
             print("")

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -64,7 +64,7 @@ class ForLoopElement(troi.Element):
                     if self.patch_args["echo"]:
                         playlist.print()
 
-                    metadata = { "source_patch": patch_slug }
+                    metadata = {"algorithm_metadata": {"source_patch": patch_slug }}
                     if self.patch_args["upload"]:
                         if not self.patch_args["token"] or self.patch_args["token"] == "":
                             raise PipelineError("In order to upload a playlist an auth token must be provided. Use --token")
@@ -73,10 +73,10 @@ class ForLoopElement(troi.Element):
                             if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
                                 playlist.submit(self.patch_args["token"],
                                                 self.patch_args["created_for"],
-                                                algorithm_metadata=metadata)
+                                                additional_metadata=metadata)
                             else:
                                 playlist.submit(self.patch_args["token"],
-                                                algorithm_metadata=metadata)
+                                                additional_metadata=metadata)
                         except troi.PipelineError as err:
                             print("Failed to submit playlist: %s, continuing..." % err, file=sys.stderr)
                             continue


### PR DESCRIPTION
metabrainz/listenbrainz-server#2239 adds additional_metadata to replace alogrithm_metadata. algorithm_metadata is now a key inside the additional_metadata dict.