### PR TITLE
Improve support for additional playlist metadata

### DIFF
--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 import logging
 import random
+from typing import Dict
 
+from troi.utils import recursively_update_dict
 
 DEVELOPMENT_SERVER_URL = "https://datasets.listenbrainz.org"
 
@@ -259,7 +261,7 @@ class Playlist(Entity):
     """
     def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
                  year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None,
-                 external_urls=None):
+                 additional_metadata=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
@@ -268,10 +270,17 @@ class Playlist(Entity):
         self.description = description
         self.patch_slug = patch_slug
         self.user_name = user_name
-        self.external_urls = external_urls
+        self.additional_metadata = additional_metadata
 
     def __str__(self):
         return "<Playlist('%s', %s, %s)>" % (self.name, self.description, self.mbid)
+
+    def add_metadata(self, metadata: Dict):
+        """ Update the playlist's additional metadata recursively """
+        if self.additional_metadata is None:
+            self.additional_metadata = {}
+
+        recursively_update_dict(self.additional_metadata, metadata)
 
     def shuffle(self, index=None):
         """ Shuffle the playlists randomly, making no effort to make it "nice" for humans. Screw humans

--- a/troi/core.py
+++ b/troi/core.py
@@ -85,11 +85,6 @@ def generate_playlist(patch: Patch, args: Dict):
         print("Playlist does not have at least %d recordings, stopping." % min_recordings)
         return None
 
-    created_for = patch_args["created_for"]
-    if result is not None and token and upload:
-        for url, _ in playlist.submit(token, created_for):
-            print("Submitted playlist: %s" % url)
-
     save = patch_args["save"]
     if result is not None and spotify and upload:
         for url, _ in playlist.submit_to_spotify(
@@ -99,6 +94,11 @@ def generate_playlist(patch: Patch, args: Dict):
                 spotify["is_collaborative"]
         ):
             print("Submitted playlist to spotify: %s" % url)
+
+    created_for = patch_args["created_for"]
+    if result is not None and token and upload:
+        for url, _ in playlist.submit(token, created_for):
+            print("Submitted playlist: %s" % url)
 
     if result is not None and save:
         playlist.save()

--- a/troi/internal/yim_patch_runner.py
+++ b/troi/internal/yim_patch_runner.py
@@ -45,10 +45,12 @@ class YIMSubmitterElement(Element):
                 f.write("%s\n" % playlist.user_name)
                 f.write("%s\n" % playlist.mbid)
 
+                playlist.add_metadata(metadata)
+
                 # This is hacky and should be moved to playlist
                 playlist_element = PlaylistElement()
-                playlist_element.playlists = [ playlist ]
-                playlist_element.save(track_count=5, additional_metadata=metadata, file_obj=f)
+                playlist_element.playlists = [playlist]
+                playlist_element.save(track_count=5, file_obj=f)
                 f.write("\n")
 
             print("")

--- a/troi/loops.py
+++ b/troi/loops.py
@@ -63,20 +63,16 @@ class ForLoopElement(troi.Element):
 
                     if self.patch_args["echo"]:
                         playlist.print()
-
-                    metadata = {"algorithm_metadata": {"source_patch": patch_slug }}
+                    playlist.add_metadata({"algorithm_metadata": {"source_patch": patch_slug}})
                     if self.patch_args["upload"]:
                         if not self.patch_args["token"] or self.patch_args["token"] == "":
                             raise PipelineError("In order to upload a playlist an auth token must be provided. Use --token")
 
                         try:
                             if self.patch_args["created_for"] and self.patch_args["created_for"] != "":
-                                playlist.submit(self.patch_args["token"],
-                                                self.patch_args["created_for"],
-                                                additional_metadata=metadata)
+                                playlist.submit(self.patch_args["token"], self.patch_args["created_for"])
                             else:
-                                playlist.submit(self.patch_args["token"],
-                                                additional_metadata=metadata)
+                                playlist.submit(self.patch_args["token"])
                         except troi.PipelineError as err:
                             print("Failed to submit playlist: %s, continuing..." % err, file=sys.stderr)
                             continue

--- a/troi/tests/test_playlist.py
+++ b/troi/tests/test_playlist.py
@@ -192,4 +192,4 @@ class TestSpotifySubmission(unittest.TestCase):
             ]
         })
 
-        self.assertEqual(playlist.playlists[0].external_urls, [playlist_url])
+        self.assertEqual(playlist.playlists[0].additional_metadata["external_urls"]["spotify"], playlist_url)

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -94,8 +94,10 @@ def fixup_spotify_playlist(sp: spotipy.Spotify, playlist_id: str, mbid_spotify_i
         return
 
     alternative_ids, index = _get_alternative_track_ids(unplayable, mbid_spotify_id_idx, spotify_id_mbid_idx)
-    fixed_up = _get_fixed_up_tracks(sp, alternative_ids, index)
+    if not alternative_ids:
+        return
 
+    fixed_up = _get_fixed_up_tracks(sp, alternative_ids, index)
     all_items = []
     all_items.extend(playable)
     all_items.extend(fixed_up)

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -58,11 +58,17 @@ def discover_patches_from_dir(module_path, patch_dir, add_dot=False):
 
 
 def recursively_update_dict(source, overrides):
-    """ Update a nested dictionary recursively in place. """
+    """ Updates the `source` dictionary in place and in a recursive fashion. That is unlike
+    dict1.update(dict2) which would simply replace values of keys even in case one of the
+    values is dict, this method will attempt to merge the nested dicts.
+
+    Eg: dict1 - {"a": {"b": 1}}, dict2 - {"a": {"c": 2}}
+    dict1.update(dict2) - {"a": {"c": 2}}
+    recursively_update_dict(dict1, dict2) - {"a": {"b": 1, "c": 2}}
+    """
     for key, value in overrides.items():
         if isinstance(value, dict) and value:
-            updated = recursively_update_dict(source.get(key, {}), value)
-            source[key] = updated
+            source[key] = recursively_update_dict(source.get(key, {}), value)
         else:
             source[key] = overrides[key]
     return source

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -4,9 +4,7 @@ import os
 import traceback
 import sys
 
-from troi import Element, Artist, Recording, Playlist
 import troi.patch
-from troi.print_recording import PrintRecordingList
 
 
 def discover_patches():
@@ -59,53 +57,13 @@ def discover_patches_from_dir(module_path, patch_dir, add_dot=False):
     return patch_dict
 
 
-def print_entity_list(entities, count=0):
-    """
-        Print the given entities in a readble fashion. If count is specified,
-        print only count number of entities.
-    """
+def recursively_update_dict(source, overrides):
+    """ Update a nested dictionary recursively in place. """
+    for key, value in overrides.items():
+        if isinstance(value, dict) and value:
+            updated = recursively_update_dict(source.get(key, {}), value)
+            source[key] = updated
+        else:
+            source[key] = overrides[key]
+    return source
 
-    if len(entities) == 0:
-        print("[ empty entity list ]")
-        return
-
-    if count == 0:
-        count = len(entities)
-
-    if isinstance(entities[0], Artist): 
-        print("artist list")
-        for e in entities[:count]:
-            print("  %s %s" % (e.mbid)[:5], e.name)
-    elif isinstance(entities[0], Recording): 
-        print("recording list")
-        for e in entities[:count]:
-            if e.artist:
-                print("  %s %-41s %s" % (e.mbid[:5], e.name[:80], e.artist.name[:60]))
-            else:
-                print("  %s %-41s" % (e.mbid[:5], e.name[:80] if e.name else ""))
-
-    print()
-
-
-class DumpElement(Element):
-    """
-        Accept whatever and print it out in a reasonably sane manner.
-    """
-
-    def __init__(self):
-        super().__init__()
-
-    @staticmethod
-    def inputs():
-        return [Recording, Playlist]
-
-    @staticmethod
-    def outputs():
-        return [Recording, Playlist]
-
-    def read(self, inputs):
-        for input in inputs:
-            pr = PrintRecordingList()
-            pr.print(input)
-
-        return inputs[0]


### PR DESCRIPTION
1. Store external uris of the playlist in additional metadata.
2. Add methods to easily update additional metadata of the playlist. These are needed so that adding some metadata in a function does not override the existing data and so that we don't need to have such checks in multiple places.
3. Move DumpElement from utils to playlist to avoid circular import issues.
4. Export to spotify before uploading to LB so that the external url is uploaded to LB through additional_metadata.
5. Unrelated: fix a spotify playlist fixup when there are no alternative ids available to fix up tracks.