### PR TITLE
Improve spotify playlist handling

### DIFF
--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -263,7 +263,7 @@ class PlaylistElement(Element):
             print("submit %d tracks" % len(spotify_track_ids))
 
             playlist_id, playlist_url = None, None
-            if existing_urls and idx < len(existing_urls):
+            if existing_urls and idx < len(existing_urls) and existing_urls[idx]:
                 # update existing playlist
                 playlist_url = existing_urls[idx]
                 playlist_id = playlist_url.split("/")[-1]

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -194,7 +194,7 @@ class PlaylistElement(Element):
             else:
                 file_obj.write(json.dumps(_serialize_to_jspf(playlist, track_count=track_count)))
 
-    def submit(self, token, created_for=None, additional_metadata=None):
+    def submit(self, token, created_for=None):
         """
             Submit the playlist to ListenBrainz.
 
@@ -213,7 +213,7 @@ class PlaylistElement(Element):
                 continue
 
             print("submit %d tracks" % len(playlist.recordings))
-            if additional_metadata is None and playlist.patch_slug is not None:
+            if playlist.patch_slug is not None:
                 playlist.add_metadata({"algorithm_metadata": {"source_patch": playlist.patch_slug}})
             r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,
                               json=_serialize_to_jspf(playlist, created_for),


### PR DESCRIPTION
Handle case if user has deleted spotify playlist

If the spotify url provided to update existing playlist returns an error, it means that the user may have unfollowed/deleted it from spotify. In that case, attempt to create a new playlist.

Do not attempt to update existing playlist if url is None