### PR TITLE
Use an auth token for extended ratelimit

### DIFF
--- a/troi/core.py
+++ b/troi/core.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import http.client
 import sys
 from typing import Dict
 
@@ -9,8 +8,6 @@ import troi
 import troi.playlist
 import troi.utils
 from troi.patch import Patch
-
-http.client.HTTPConnection.debuglevel = 1
 
 default_patch_args = dict(
     debug=False,

--- a/troi/core.py
+++ b/troi/core.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import http.client
 import sys
 from typing import Dict
 
@@ -9,6 +9,8 @@ import troi
 import troi.playlist
 import troi.utils
 from troi.patch import Patch
+
+http.client.HTTPConnection.debuglevel = 1
 
 default_patch_args = dict(
     debug=False,

--- a/troi/listenbrainz/listens.py
+++ b/troi/listenbrainz/listens.py
@@ -16,13 +16,15 @@ class RecentListensTimestampLookup(Element):
         Timestamps are stored in the listenbrainz dict, with key name "latest_listened_at".
 
         :param user_name: The ListenBrainz user for whome to fetch recent listen timestamps.
+        :param auth_token: a ListenBrainz auth token
         :param days: The number of days to check.
     """
 
-    def __init__(self, user_name, days: int):
+    def __init__(self, user_name, days: int, auth_token=None):
         super().__init__()
         self.user_name = user_name
         self.days = days
+        self.auth_token = auth_token
         self.index: Optional[dict[str, int]] = None
 
     @staticmethod
@@ -42,9 +44,11 @@ class RecentListensTimestampLookup(Element):
         min_dt = datetime.now() + timedelta(days=-self.days)
         min_ts = int(min_dt.timestamp())
         while True:
+            headers = {"Authorization": f"Token {self.auth_token}"} if self.auth_token else {}
             response = requests.get(
                 f"https://api.listenbrainz.org/1/user/{self.user_name}/listens",
-                params={"min_ts": min_ts, "count": 100}
+                params={"min_ts": min_ts, "count": 100},
+                headers=headers
             )
             if response.status_code == 429:
                 sleep(2)

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -19,9 +19,11 @@ class UserRecordingRecommendationsElement(Element):
 
     MAX_RECORDINGS_TO_FETCH = 2000
 
-    def __init__(self, user_name, artist_type, count=25, offset=0):
+    def __init__(self, user_name, artist_type, count=25, offset=0, auth_token=None):
         super().__init__()
         self.client = pylistenbrainz.ListenBrainz()
+        if auth_token:
+            self.client.set_auth_token(auth_token)
         self.user_name = user_name
         self.count = count
         self.offset = offset

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -57,9 +57,9 @@ class DailyJamsPatch(troi.patch.Patch):
         if jam_date is None:
             jam_date = datetime.utcnow().strftime("%Y-%m-%d %a")
 
-        recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name, "raw", count=1000, auth_token=inputs.get("auth_token"))
+        recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name, "raw", count=1000, auth_token=inputs.get("token"))
 
-        recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2, auth_token=inputs.get("auth_token"))
+        recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2, auth_token=inputs.get("token"))
         recent_listens_lookup.set_sources(recs)
 
         # Remove tracks that have not been listened to before.

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -57,9 +57,9 @@ class DailyJamsPatch(troi.patch.Patch):
         if jam_date is None:
             jam_date = datetime.utcnow().strftime("%Y-%m-%d %a")
 
-        recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name, "raw", count=1000)
+        recs = troi.listenbrainz.recs.UserRecordingRecommendationsElement(user_name, "raw", count=1000, auth_token=inputs.get("auth_token"))
 
-        recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2)
+        recent_listens_lookup = troi.listenbrainz.listens.RecentListensTimestampLookup(user_name, days=2, auth_token=inputs.get("auth_token"))
         recent_listens_lookup.set_sources(recs)
 
         # Remove tracks that have not been listened to before.
@@ -69,7 +69,7 @@ class DailyJamsPatch(troi.patch.Patch):
         latest_filter = troi.filters.LatestListenedAtFilterElement(DAYS_OF_RECENT_LISTENS_TO_EXCLUDE)
         latest_filter.set_sources(never_listened)
 
-        feedback_lookup = troi.listenbrainz.feedback.ListensFeedbackLookup(user_name)
+        feedback_lookup = troi.listenbrainz.feedback.ListensFeedbackLookup(user_name, auth_token=inputs.get("auth_token"))
         feedback_lookup.set_sources(latest_filter)
 
         recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()

--- a/troi/patches/daily_jams.py
+++ b/troi/patches/daily_jams.py
@@ -69,7 +69,7 @@ class DailyJamsPatch(troi.patch.Patch):
         latest_filter = troi.filters.LatestListenedAtFilterElement(DAYS_OF_RECENT_LISTENS_TO_EXCLUDE)
         latest_filter.set_sources(never_listened)
 
-        feedback_lookup = troi.listenbrainz.feedback.ListensFeedbackLookup(user_name, auth_token=inputs.get("auth_token"))
+        feedback_lookup = troi.listenbrainz.feedback.ListensFeedbackLookup(user_name, auth_token=inputs.get("token"))
         feedback_lookup.set_sources(latest_filter)
 
         recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()


### PR DESCRIPTION
Daily jams are failing for users in production due to ratelimit errors. The intent is to pass troi's auth token to the patch in prod so that the ratelimit can be bypassed.