### PR TITLE
Fix periodic patch slug

### DIFF
--- a/troi/patches/periodic_jams.py
+++ b/troi/patches/periodic_jams.py
@@ -109,7 +109,7 @@ class PeriodicJamsPatch(troi.patch.Patch):
 
         pl_maker = PlaylistMakerElement(name="%s for %s, %s" % (jam_name, user_name, jam_date),
                                         desc="%s playlist!" % jam_name,
-                                        patch_slug=self.slug(),
+                                        patch_slug=jam_type,
                                         max_num_recordings=50,
                                         max_artist_occurrence=2,
                                         shuffle=True,


### PR DESCRIPTION
In the previous PR the slug was set to period-jams, which doesn't allow us to distinguish between weekly-jams, daily-jams and weekly-new-jams. Setting the slug according to type fixes this.