### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: docs/conf.py
+
+formats: all
+
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
read the docs warns us that we need to update our config:
  
   https://blog.readthedocs.com/migrate-configuration-v2/

This PR copies the config file used for lb.