### PR TITLE
Add support for expires_at in additional_metadata and add descriptios for periodic playlists

### DIFF
--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -266,7 +266,7 @@ class Playlist(Entity):
     """
     def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
                  year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None,
-                 additional_metadata=None, expire_at=None):
+                 additional_metadata=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
@@ -275,7 +275,6 @@ class Playlist(Entity):
         self.description = description
         self.patch_slug = patch_slug
         self.user_name = user_name
-        self.expire_at = expire_at
         self.additional_metadata = additional_metadata
 
     def __str__(self):

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -266,7 +266,7 @@ class Playlist(Entity):
     """
     def __init__(self, name=None, mbid=None, filename=None, recordings=None, description=None, ranking=None,
                  year=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None, patch_slug=None, user_name=None,
-                 additional_metadata=None):
+                 additional_metadata=None, expire_at=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
         self.name = name
         self.filename = filename
@@ -275,6 +275,7 @@ class Playlist(Entity):
         self.description = description
         self.patch_slug = patch_slug
         self.user_name = user_name
+        self.expire_at = expire_at
         self.additional_metadata = additional_metadata
 
     def __str__(self):

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -420,6 +420,7 @@ class PlaylistMakerElement(Element):
                  max_num_recordings=None,
                  max_artist_occurrence=None,
                  shuffle=False,
+                 expires_at=False,
                  is_april_first=False):
         super().__init__()
         self.name = name
@@ -429,6 +430,7 @@ class PlaylistMakerElement(Element):
         self.max_num_recordings = max_num_recordings
         self.max_artist_occurrence = max_artist_occurrence
         self.shuffle = shuffle
+        self.expires_at = expires_at
         self.is_april_first = is_april_first
 
     @staticmethod
@@ -471,6 +473,9 @@ class PlaylistMakerElement(Element):
                             user_name=self.user_name)
         if self.shuffle:
             playlist.shuffle()
+
+        if self.expires_at is not None:
+            playlist.add_metadata({ "expires_at": self.expires_at.isoformat() })
 
         if self.is_april_first:
             try:


### PR DESCRIPTION
The bulk generation of playlists doesn't have good playlist descriptions, so this PR adds those to the troi patch, for easy reference from the listenbrainz codebase.

Also in this PR is support for expires_at in playlist's additional_metadata field, so that we know when a playlist is due to expire and can clearly show a timer icon to our users.