### PR TITLE
Allow sending JSPF files to spotify

### DIFF
--- a/troi/patch.py
+++ b/troi/patch.py
@@ -93,5 +93,5 @@ class Patch(ABC):
         """
         try:
             return self.local_storage["user_feedback"]
-        except IndexError:
-            return None
+        except KeyError:
+            return []

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -38,16 +38,18 @@ class TransferPlaylistPatch(troi.patch.Patch):
 
     def create(self, inputs):
 
-        if inputs["mbid"] is not None and inputs["jspf"] is not None:
+        mbid = inputs.get("mbid", None)
+        jspf = inputs.get("jspf", None)
+
+        if mbid is not None and jspf is not None:
             raise RuntimeError("Cannot pass both playlist mbid and jspf to TransferPlaylistPatch.")
 
-        if inputs["mbid"] is None and inputs["jspf"] is None:
+        if mbid is None and jspf is None:
             raise RuntimeError("Must pass either playlist mbid or jspf to TransferPlaylistPatch, not both.")
 
-        if inputs["jspf"] is not None:
-            jspf = inputs["jspf"]
+        if jspf is not None:
             if isinstance(jspf, str):
-                jspf = json.reads(str)
+                jspf = json.reads(jspf)
 
         token = inputs.get("read_only_token") or inputs.get("token")
-        return PlaylistFromJSPFElement(playlist_mbid=inputs["mbid"], jspf=jspf, token=token)
+        return PlaylistFromJSPFElement(playlist_mbid=mbid, jspf=jspf, token=token)

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -13,7 +13,8 @@ class TransferPlaylistPatch(troi.patch.Patch):
         A dummy patch that retrieves an existing playlist from ListenBrainz or raw JSPF for use in Troi.
 
         \b
-        MBID is the playlist mbid to save again.
+        MBID is the playlist mbid to save. Specify this OR JSPF.
+        JSPF is the actual JSPF playlist to transfer. Specify this OR MBID.
         READ_ONLY_TOKEN is the listenbrainz auth token to retrieve the playlist if its private. If not specified,
         fallback to TOKEN. Both arguments take the same value but specifying TOKEN may also upload the playlist
         to LB again which is many times not desirable.
@@ -40,12 +41,17 @@ class TransferPlaylistPatch(troi.patch.Patch):
 
         mbid = inputs.get("mbid", None)
         jspf = inputs.get("jspf", None)
+    
+        if mbid == "":
+            mbid = None
+        if jspf == "":
+            jspf = None
 
         if mbid is not None and jspf is not None:
             raise RuntimeError("Cannot pass both playlist mbid and jspf to TransferPlaylistPatch.")
 
         if mbid is None and jspf is None:
-            raise RuntimeError("Must pass either playlist mbid or jspf to TransferPlaylistPatch, not both.")
+            raise RuntimeError("Must pass either playlist mbid or jspf to TransferPlaylistPatch.")
 
         if jspf is not None:
             if isinstance(jspf, str):

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -39,8 +39,8 @@ class TransferPlaylistPatch(troi.patch.Patch):
 
     def create(self, inputs):
 
-        mbid = inputs.get("mbid", None)
-        jspf = inputs.get("jspf", None)
+        mbid = inputs["mbid"]
+        jspf = inputs["jspf"]
     
         if mbid == "":
             mbid = None
@@ -55,7 +55,7 @@ class TransferPlaylistPatch(troi.patch.Patch):
 
         if jspf is not None:
             if isinstance(jspf, str):
-                jspf = json.reads(jspf)
+                jspf = json.loads(jspf)
 
         token = inputs.get("read_only_token") or inputs.get("token")
         return PlaylistFromJSPFElement(playlist_mbid=mbid, jspf=jspf, token=token)

--- a/troi/patches/playlist_from_listenbrainz.py
+++ b/troi/patches/playlist_from_listenbrainz.py
@@ -41,7 +41,7 @@ class TransferPlaylistPatch(troi.patch.Patch):
 
         mbid = inputs["mbid"]
         jspf = inputs["jspf"]
-    
+
         if mbid == "":
             mbid = None
         if jspf == "":
@@ -53,9 +53,8 @@ class TransferPlaylistPatch(troi.patch.Patch):
         if mbid is None and jspf is None:
             raise RuntimeError("Must pass either playlist mbid or jspf to TransferPlaylistPatch.")
 
-        if jspf is not None:
-            if isinstance(jspf, str):
-                jspf = json.loads(jspf)
+        if isinstance(jspf, str):
+            jspf = json.loads(jspf)
 
         token = inputs.get("read_only_token") or inputs.get("token")
         return PlaylistFromJSPFElement(playlist_mbid=mbid, jspf=jspf, token=token)

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -95,9 +95,13 @@ def _deserialize_from_jspf(data) -> Playlist:
 
         recordings.append(recording)
 
+    try:
+        ident = data["identifier"].split("/")[-1],
+    except KeyError:
+        ident = ""
     playlist = Playlist(name=data["title"],
                         description=data.get("annotation"),
-                        mbid=data["identifier"].split("/")[-1],
+                        mbid=ident,
                         recordings=recordings)
     return playlist
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -468,30 +468,39 @@ class PlaylistMakerElement(Element):
 
 
 class PlaylistFromJSPFElement(Element):
-    """ Create a troi.Playlist entity from a ListenBrainz JSPF playlist """
+    """ Create a troi.Playlist entity from a ListenBrainz JSPF playlist or LB playlist."""
 
-    def __init__(self, playlist_mbid, token=None):
+    def __init__(self, playlist_mbid=None, jspf=None, token=None):
         """
+            The caller must pass either playlist_mbid or the jspf itself, but not both.
             Args:
                 playlist_mbid: mbid of the ListenBrainz playlist to be used for creating the playlist element
+                jspf: The actual JSPF for the playlist.
                 token: the listenbrainz auth token to fetch the playlist, only needed for private playlists
         """
         super().__init__()
         self.playlist_mbid = playlist_mbid
         self.token = token
+        self.jspf = jspf
+
+        if self.jspf is not None and self.playlist_mbid is not None:
+            raise RuntimeError("Pass either jspf or playlist_mbid to PlaylistFromJSPFElement, not both.")
 
     @staticmethod
     def outputs():
         return [Playlist]
 
     def read(self, inputs):
-        headers = None
-        if self.token:
-            headers = {"Authorization": f"Token {self.token}"}
-        response = requests.get(LISTENBRAINZ_PLAYLIST_FETCH_URL + self.playlist_mbid, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-        return [_deserialize_from_jspf(data)]
+        if self.playlist_mbid:
+            headers = None
+            if self.token:
+                headers = {"Authorization": f"Token {self.token}"}
+            response = requests.get(LISTENBRAINZ_PLAYLIST_FETCH_URL + self.playlist_mbid, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            return [_deserialize_from_jspf(data)]
+        else:
+            return [_deserialize_from_jspf(self.jspf)]
 
 
 class DumpElement(Element):


### PR DESCRIPTION
This PR opens the possibility for sending playlists that have not been saved to LB to be transferred to Spotify. This functionality will be used in LB radio.