### PR TITLE
Prompt parsing fixes

### DIFF
--- a/docs/lb_radio.rst
+++ b/docs/lb_radio.rst
@@ -81,13 +81,49 @@ This idea of modes comes from video games, where players can choose how hard the
 the resultant playlist will also be more work to listen to the harder the mode. Which mode to use is entirely up to the user -- easy
 is likely going to create a playlist with familiar music, and a hard playlist may expose you to less familiar music.
 
+Syntax Notes
+------------
+
+The syntax attempts to be intuitive and simple, but it does have some limitations. The artist: entity has the most tricky restrictions
+because it should accept the full name of an artist. For latin character sets, the short form for an artist name can be used:
+
+::
+
+  artist:Blümchen
+  artist:The Knife
+
+But, if you need other unicode characters, the name must be enclosed by ():
+
+::
+
+  artist:(Мумий Тролль)
+
+Furthermore, artist names must be spelled exactly as their appear in MusicBrainz.
+
+Tags have similar restrictions. If a tag you'd like to specify has no spaces or non-latin unicode characters you may use:
+
+::
+
+  tag:punk 
+  #punk
+
+But with spaces or non-latin unicode characters, wrap it in ():
+
+::
+
+  tag:(hip hop)
+
+::
+
+  tag:(あなたを決して裏切りません)
+
 
 Simple examples
 ---------------
 
 ::
 
-  artist:(Rick Astley)
+  artist:Rick Astley
 
 Create a single stream, from artist Rick Astley and similar artists. Artist names must be spelled here exactly as they are
 spelled in MusicBrainz. If for some reason the artist name is not recognized, specify an MBID instead. See below.

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -25,7 +25,7 @@ def build_parser():
     recs_element = pp.MatchFirst((pp.Keyword("recs"), pp.Keyword("r")))
 
     # Define the various text fragments/identifiers that we plan to use
-    text = pp.Word(pp.identbodychars)
+    text = pp.Word(pp.identbodychars + " ")
     uuid = pp.pyparsing_common.uuid()
     paren_text = pp.QuotedString("(", end_quote_char=")")
     ws_tag = pp.OneOrMore(pp.Word(pp.srange("[a-zA-Z0-9-_ !@$%^&*=+;'/]")))

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -124,7 +124,7 @@ def parse(prompt: str):
 
     parser = build_parser()
     try:
-        elements = parser.parseString(prompt, parseAll=True)
+        elements = parser.parseString(prompt.lower(), parseAll=True)
     except pp.exceptions.ParseException as err:
         raise ParseError(err)
 

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -25,7 +25,7 @@ def build_parser():
     recs_element = pp.MatchFirst((pp.Keyword("recs"), pp.Keyword("r")))
 
     # Define the various text fragments/identifiers that we plan to use
-    text = pp.Word(pp.alphanums + "_")
+    text = pp.Word(pp.identbodychars)
     uuid = pp.pyparsing_common.uuid()
     paren_text = pp.QuotedString("(", end_quote_char=")")
     ws_tag = pp.OneOrMore(pp.Word(pp.srange("[a-zA-Z0-9-_ !@$%^&*=+;'/]")))

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -30,7 +30,7 @@ class LBRadioArtistRecordingElement(troi.Element):
     """
 
     MAX_TOP_RECORDINGS_PER_ARTIST = 35  # should lower this when other sources of data get added
-    MAX_NUM_SIMILAR_ARTISTS = 12
+    MAX_NUM_SIMILAR_ARTISTS = 6
 
     def __init__(self, artist_mbid, mode="easy", include_similar_artists=True):
         troi.Element.__init__(self)

--- a/troi/tests/test_parser.py
+++ b/troi/tests/test_parser.py
@@ -15,6 +15,9 @@ class TestParser(unittest.TestCase):
 
         self.assertRaises(ParseError, parse, "wrong:57baa3c6-ee43-4db3-9e6a-50bbc9792ee4")
 
+        r = parse("artist:the knife")
+        assert r[0] == {"entity": "artist", "values": ["the knife"], "weight": 1, "opts": []}
+
     def test_tags(self):
         r = parse("t:abstract t:rock t:blues")
         assert r[0] == {"entity": "tag", "values": ["abstract"], "weight": 1, "opts": []}


### PR DESCRIPTION
Putting LB radio in front of a speaker of a non-latin based language showed a number of issues right off the bat. lol.

This PR:
- Allows for spaces in artist names.
- Allows latin characters in artist names outside of parens. Unicode only in parens.
- Fetch only 6 similar artists for the artist entity
- Update docs to explain syntax a bit.