### PR TITLE
Improve error handling for LB-radio

### DIFF
--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -38,7 +38,7 @@ class RecordingLookupElement(Element):
 
         data = []
         for r in recordings:
-            if r.artist.name == "" or len(r.artist.mbids) == 0 or r.name == "":
+            if r.artist is None or r.artist.name == "" or len(r.artist.mbids) == 0 or r.name == "":
                 data.append({ '[recording_mbid]': r.mbid })
 
         # If we have all the data for all the recordings, no need to lookup anything and simply pass the data along

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -38,7 +38,12 @@ class RecordingLookupElement(Element):
 
         data = []
         for r in recordings:
-            data.append({ '[recording_mbid]': r.mbid })
+            if r.artist.name == "" or len(r.artist.mbids) == 0 or r.name == "":
+                data.append({ '[recording_mbid]': r.mbid })
+
+        # If we have all the data for all the recordings, no need to lookup anything and simply pass the data along
+        if len(data) == 0:
+            return inputs[0]
 
         self.debug("- debug %d recordings" % len(recordings))
 

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -113,6 +113,19 @@ def build_parser():
     return pp.OneOrMore(pp.Group(elements, aslist=True))
 
 
+def common_error_check(prompt: str):
+    """ Pyparsing is amazing, but the error messages leave a lot to be desired. This function attempts
+    to scan for common problems and give better error messages."""
+
+    parts = prompt.split(":")
+    try:
+        if parts[2] in OPTIONS:
+            sugg = f"{parts[0]}:{parts[1]}::{parts[2]}"
+            raise ParseError("Syntax error: options specified in the weight field, since a : is missing. Did you mean '%s'?" % sugg)
+    except IndexError:
+        pass
+
+
 def parse(prompt: str):
     """ Parse the given prompt. Return an array of dicts that contain the following keys:
           entity: str  e.g. "artist"
@@ -122,6 +135,8 @@ def parse(prompt: str):
 
         raises ParseError if, well, a parse error is encountered. 
     """
+
+    common_error_check(prompt)
 
     parser = build_parser()
     try:
@@ -148,7 +163,7 @@ def parse(prompt: str):
 
         try:
             if entity == "tag" and element[1][0].find(",") > 0:
-                element[1] = [ s.strip() for s in element[1][0].split(",") ]
+                element[1] = [s.strip() for s in element[1][0].split(",")]
         except IndexError:
             pass
 

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -68,7 +68,7 @@ def build_parser():
                 + optional
     element_paren_tag = tag_element \
                       + pp.Suppress(pp.Literal(':')) \
-                      + pp.Group(paren_tag, aslist=True) \
+                      + pp.Group(paren_text, aslist=True) \
                       + optional
     element_tag_shortcut = pp.Literal('#') \
                          + pp.Group(tag, aslist=True) \
@@ -145,6 +145,12 @@ def parse(prompt: str):
             entity = "tag"
         else:
             entity = element[0]
+
+        try:
+            if entity == "tag" and element[1][0].find(",") > 0:
+                element[1] = [ s.strip() for s in element[1][0].split(",") ]
+        except IndexError:
+            pass
 
         try:
             values = [UUID(element[1][0])]

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -28,8 +28,9 @@ def build_parser():
     text = pp.Word(pp.identbodychars + " ")
     uuid = pp.pyparsing_common.uuid()
     paren_text = pp.QuotedString("(", end_quote_char=")")
-    ws_tag = pp.OneOrMore(pp.Word(pp.srange("[a-zA-Z0-9-_ !@$%^&*=+;'/]")))
-    tag = pp.Word(pp.srange("[a-zA-Z0-9-_!@$%^&*=+;'/]"))
+    tag_chars = pp.identbodychars + "&!-@$%^*=+;'"
+    ws_tag = pp.OneOrMore(pp.Word(tag_chars + " "))
+    tag = pp.Word(tag_chars)
 
     # Define supporting fragments that will be used multiple times
     paren_tag = pp.Suppress(pp.Literal("(")) \

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -30,7 +30,7 @@ class LBRadioArtistRecordingElement(troi.Element):
     """
 
     MAX_TOP_RECORDINGS_PER_ARTIST = 35  # should lower this when other sources of data get added
-    MAX_NUM_SIMILAR_ARTISTS = 6
+    MAX_NUM_SIMILAR_ARTISTS = 8
 
     def __init__(self, artist_mbid, mode="easy", include_similar_artists=True):
         troi.Element.__init__(self)
@@ -80,13 +80,20 @@ class LBRadioArtistRecordingElement(troi.Element):
             Given and artist_mbid, fetch top recordings for this artist and retun them in a plist.
         """
 
-        r = requests.post("https://datasets.listenbrainz.org/popular-recordings/json", json=[{
-            '[artist_mbid]': artist_mbid,
-        }])
+        r = requests.get("https://api.listenbrainz.org/1/popularity/top-recordings-for-artist", params={"artist_mbid": artist_mbid})
         if r.status_code != 200:
             raise RuntimeError(f"Cannot fetch top artist recordings: {r.status_code} ({r.text})")
 
-        return plist(r.json())
+        recordings = plist()
+        for recording in r.json():
+            artist = Artist(mbids=recording["artist_mbids"], name=recording["artist_name"])
+            recordings.append(
+                Recording(mbid=recording["recording_mbid"],
+                          name=recording["recording_name"],
+                          length=recording["length"],
+                          artist=artist))
+
+        return recordings
 
     def fetch_artist_names(self, artist_mbids):
         """
@@ -138,7 +145,7 @@ class LBRadioArtistRecordingElement(troi.Element):
         self.local_storage["user_feedback"].append(msg)
         self.data_cache["element-descriptions"].append("artist %s" % artists[0]["name"])
 
-        # Deremine percent ranges based on mode -- this will likely need further tweaking
+        # Determine percent ranges based on mode -- this will likely need further tweaking
         if self.mode == "easy":
             start, stop = 0, 50
         elif self.mode == "medium":
@@ -153,11 +160,10 @@ class LBRadioArtistRecordingElement(troi.Element):
                 artist["recordings"] = self.data_cache[artist["mbid"] + "_top_recordings"]
                 continue
 
-            mbid_plist = plist(self.fetch_top_recordings(artist["mbid"]))
+            recs_plist = plist(self.fetch_top_recordings(artist["mbid"]))
             recordings = []
-
-            for recording in mbid_plist.random_item(start, stop, self.max_top_recordings_per_artist):
-                recordings.append(Recording(mbid=recording["recording_mbid"]))
+            for recording in recs_plist.random_item(start, stop, self.max_top_recordings_per_artist):
+                recordings.append(recording)
 
             # Now tuck away the data for caching and interleaving
             self.data_cache[artist["mbid"] + "_top_recordings"] = recordings

--- a/troi/patches/lb_radio_classes/recs.py
+++ b/troi/patches/lb_radio_classes/recs.py
@@ -53,7 +53,7 @@ class LBRadioRecommendationRecordingElement(troi.Element):
             except pylistenbrainz.errors.ListenBrainzAPIException as err:
                 raise RuntimeError("Cannot fetch recording stats for user %s" % self.user_name)
 
-            if len(result['payload']['mbids']) == 0:
+            if result is None or len(result['payload']['mbids']) == 0:
                 break
 
             # Turn them into recordings

--- a/troi/patches/lb_radio_classes/stats.py
+++ b/troi/patches/lb_radio_classes/stats.py
@@ -48,6 +48,9 @@ class LBRadioStatsRecordingElement(troi.Element):
         except pylistenbrainz.errors.ListenBrainzAPIException as err:
             raise RuntimeError("Cannot fetch recording stats for user %s" % self.user_name)
 
+        if result is None or "recordings" not in result["payload"]:
+            raise RuntimeError("There are no stats available for user '%s' for the %s time_range." % (self.user_name, self.time_range))
+
         # Give feedback on what we collected
         self.local_storage["data_cache"]["element-descriptions"].append(f"{self.user_name}'s stats for {self.time_range}")
 

--- a/troi/tests/test_parser.py
+++ b/troi/tests/test_parser.py
@@ -50,8 +50,8 @@ class TestParser(unittest.TestCase):
         r = parse("t:(blümchen)")
         assert r[0] == {"entity": "tag", "values": ["blümchen"], "weight": 1, "opts": []}
 
-#        r = parse("t:(モーニング娘。)")
-#        assert r[0] == {"entity": "tag", "values": ["モーニング娘。"], "weight": 1, "opts": []}
+        r = parse("t:(モーニング娘。)")
+        assert r[0] == {"entity": "tag", "values": ["モーニング娘。"], "weight": 1, "opts": []}
 
     def test_tag_errors(self):
         self.assertRaises(ParseError, parse, "t:(abstract rock blues):bork")

--- a/troi/tests/test_parser.py
+++ b/troi/tests/test_parser.py
@@ -44,6 +44,15 @@ class TestParser(unittest.TestCase):
         r = parse("t:r&b")
         assert r[0] == {"entity": "tag", "values": ["r&b"], "weight": 1, "opts": []}
 
+        r = parse("t:blümchen")
+        assert r[0] == {"entity": "tag", "values": ["blümchen"], "weight": 1, "opts": []}
+
+        r = parse("t:(blümchen)")
+        assert r[0] == {"entity": "tag", "values": ["blümchen"], "weight": 1, "opts": []}
+
+#        r = parse("t:(モーニング娘。)")
+#        assert r[0] == {"entity": "tag", "values": ["モーニング娘。"], "weight": 1, "opts": []}
+
     def test_tag_errors(self):
         self.assertRaises(ParseError, parse, "t:(abstract rock blues):bork")
         self.assertRaises(ParseError, parse, "tag:(foo")

--- a/troi/tests/test_parser.py
+++ b/troi/tests/test_parser.py
@@ -18,6 +18,8 @@ class TestParser(unittest.TestCase):
         r = parse("artist:the knife")
         assert r[0] == {"entity": "artist", "values": ["the knife"], "weight": 1, "opts": []}
 
+        self.assertRaises(ParseError, parse, "artist:u2:nosim")
+
     def test_tags(self):
         r = parse("t:abstract t:rock t:blues")
         assert r[0] == {"entity": "tag", "values": ["abstract"], "weight": 1, "opts": []}


### PR DESCRIPTION
This PR improves a number of things:

- tags can now contain all latin characters if no parens are used. (e.g. tag:blümchen)
- tags can now contain unicode characters, if parens are used. (e.g. tag:(モーニング娘)
- use new popular recordings endpoint
- Use the metadata provided in the popular recordings endpoint
- Make recording lookup optional if no recordings need looking up.
- Implement common error detection and give better feedback.