### PR TITLE
Improve tag radio, add troi.py, use similar tags, other tag improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ below.
 virtualenv -p python3 .ve
 source .ve/bin/activate
 pip3 install -r requirements.txt -r requirements_test.txt
-python3 -m troi.cli --help
+python3 troi.py --help
 ```
 
 **Windows**
@@ -48,22 +48,22 @@ python3 -m troi.cli --help
 virtualenv -p python .ve
 .ve\Scripts\activate.bat
 pip install -r requirements.txt -r requirements_test.txt
-python -m troi.cli --help
+python troi.py --help
 ```
 
 ## Basic commands
 
 List available patches:
 
-    python -m troi.cli list
+    python troi.py list
 
 Generate a playlist using a patch:
 
-    python -m troi.cli playlist --print [patch-name]
+    python troi.py playlist --print [patch-name]
 
 If the patch requires arguments, running it with no arguments will print a usage statement, e.g.
 
-    $ python -m troi.cli playlist --print area-random-recordings
+    $ python troi.py playlist --print area-random-recordings
     Usage: area-random-recordings [OPTIONS] AREA START_YEAR END_YEAR
    
       Generate a list of random recordings from a given area.
@@ -78,9 +78,9 @@ If the patch requires arguments, running it with no arguments will print a usage
 ## Running tests
 
 ```
-python3 -m troi.cli test
-python3 -m troi.cli test -v
-python3 -m troi.cli test -v <file to test>
+python3 troi.py test
+python3 troi.py test -v
+python3 troi.py test -v <file to test>
 ```
 
 ## Building Documentation

--- a/docs/lb_radio.rst
+++ b/docs/lb_radio.rst
@@ -39,14 +39,15 @@ All terms have the following options:
 #. **medium**: Use medium mode for this term.
 #. **hard**: Use hard mode for this term.
 
-For artist terms, the following option applies:
+For artist and tag terms, the following option applies:
 
-#. **nosim**: Do not add similar artists, only output recordings from the given artist.
+#. **nosim**: Do not add similar artists/tags, only output recordings from the given artist/tag.
 
 For tag queries, the following options exist:
 
 #. **and**: For a tag query, if "and" is specified (the default) recordings will be chosen if all the given tags are applied to that recording.
 #. **or**: For a tag query, if "or" is specified, then recordings will be chosen if any of the tags are applied to the recording.
+#. **nosim**: Tag queries on medium and hard mode may include similar tags. Specifying nosim for a tag query ensures that no similar tags are used.
 
 For the stats term, the following options apply:
 

--- a/troi.py
+++ b/troi.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+from troi.cli import cli
+
+if __name__ == "__main__":
+    cli()
+    sys.exit(0)

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -19,6 +19,7 @@ from troi.patches.lb_radio_classes.tag import LBRadioTagRecordingElement
 from troi.patches.lb_radio_classes.stats import LBRadioStatsRecordingElement
 from troi.patches.lb_radio_classes.recs import LBRadioRecommendationRecordingElement
 from troi import TARGET_NUMBER_OF_RECORDINGS, Playlist
+from troi.utils import interleave
 
 
 class LBRadioPatch(troi.patch.Patch):

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -130,6 +130,15 @@ class LBRadioPatch(troi.patch.Patch):
             if "hard" in element["opts"]:
                 mode = "hard"
 
+            # Determine percent ranges based on mode -- this will likely need further tweaking
+            if mode == "easy":
+                start, stop = 0, 33
+            elif self.mode == "medium":
+                start, stop = 33, 66
+            else:
+                start, stop = 66, 100
+            self.local_storage["modes"] = {"easy": (0, 33), "medium": (33, 66), "hard": (66, 100)}
+
             if element["entity"] == "artist":
                 include_sim = False if "nosim" in element["opts"] else True
                 source = LBRadioArtistRecordingElement(element["values"][0], mode=mode, include_similar_artists=include_sim)

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -145,7 +145,8 @@ class LBRadioPatch(troi.patch.Patch):
                 source = LBRadioArtistRecordingElement(element["values"][0], mode=mode, include_similar_artists=include_sim)
 
             if element["entity"] == "tag":
-                source = LBRadioTagRecordingElement(element["values"], mode=mode, operator="and")
+                include_sim = False if "nosim" in element["opts"] else True
+                source = LBRadioTagRecordingElement(element["values"], mode=mode, operator="and", include_similar_tags=include_sim)
 
             if element["entity"] == "tag-or":
                 source = LBRadioTagRecordingElement(element["values"], mode=mode, operator="or")

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -4,6 +4,7 @@ import troi
 from troi import Recording, Artist
 from troi.splitter import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
+from troi.utils import interleave
 
 OVERHYPED_SIMILAR_ARTISTS = [
     "b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d",  # The Beatles
@@ -18,10 +19,6 @@ OVERHYPED_SIMILAR_ARTISTS = [
     "cc0b7089-c08d-4c10-b6b0-873582c17fd6",  # System of a Down
     "ebfc1398-8d96-47e3-82c3-f782abcdb13d",  # Beach boys
 ]
-
-
-def interleave(lists):
-    return [val for tup in zip(*lists) for val in tup]
 
 
 class LBRadioArtistRecordingElement(troi.Element):
@@ -120,15 +117,14 @@ class LBRadioArtistRecordingElement(troi.Element):
         if self.include_similar_artists:
             # Fetch similar artists for original artist
             similar_artists = self.get_similar_artists(self.artist_mbid)
-#            if len(similar_artists) == 0:
-#                raise RuntimeError(f"Not enough similar artist data available for artist {self.artist_name}. Please choose a different artist.")
+            #            if len(similar_artists) == 0:
+            #                raise RuntimeError(f"Not enough similar artist data available for artist {self.artist_name}. Please choose a different artist.")
 
-            # select artists 
+            # select artists
             for artist in similar_artists[start:stop]:
                 artists.append({"mbid": artist["artist_mbid"]})
                 if len(artists) >= self.MAX_NUM_SIMILAR_ARTISTS:
                     break
-
 
         # For all fetched artists, fetch their names
         artist_names = self.fetch_artist_names([i["mbid"] for i in artists])
@@ -146,7 +142,7 @@ class LBRadioArtistRecordingElement(troi.Element):
         if self.include_similar_artists and len(artists) == 1:
             msgs.append(f"Seed artist {artist_names[self.artist_mbid]} no similar artists.")
         else:
-            if self.include_similar_artists and len(artists)  < 4:
+            if self.include_similar_artists and len(artists) < 4:
                 msgs.append(f"Seed artist {artist_names[self.artist_mbid]} few similar artists.")
             msg = "artist: using seed artist %s" % artists[0]["name"]
             if self.include_similar_artists:
@@ -168,7 +164,8 @@ class LBRadioArtistRecordingElement(troi.Element):
 
             recs_plist = plist(self.fetch_top_recordings(artist["mbid"]))
             if len(recs_plist) < 20:
-                self.local_storage["user_feedback"].append(f"Artist {artist['name']} only has {'no' if len(recs_plist) == 0 else 'few'} top recordings.")
+                self.local_storage["user_feedback"].append(
+                    f"Artist {artist['name']} only has {'no' if len(recs_plist) == 0 else 'few'} top recordings.")
 
             recordings = []
             for recording in recs_plist.random_item(start, stop, self.max_top_recordings_per_artist):

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -16,6 +16,7 @@ OVERHYPED_SIMILAR_ARTISTS = [
     "5b11f4ce-a62d-471e-81fc-a69a8278c7da",  # Nirvana
     "f59c5520-5f46-4d2c-b2c4-822eabf53419",  # Linkin Park
     "cc0b7089-c08d-4c10-b6b0-873582c17fd6",  # System of a Down
+    "ebfc1398-8d96-47e3-82c3-f782abcdb13d",  # Beach boys
 ]
 
 

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -90,13 +90,15 @@ class LBRadioTagRecordingElement(troi.Element):
 
         if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
-            similar_tag = similar_tags.random_item(0, 50, 1)["similar_tag"]
-            msgs = [f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."]
+            similar_tag = similar_tags.random_item(0, 50, 1)
+            if similar_tag is not None:
+                similar_tag = similar_tag["similar_tag"]
+                msgs = [f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."]
 
-            sim_tag_data = self.fetch_tag_data([similar_tag], "OR", 1)
-            sim_tag_data = self.flatten_tag_data(sim_tag_data)
+                sim_tag_data = self.fetch_tag_data([similar_tag], "OR", 1)
+                sim_tag_data = self.flatten_tag_data(sim_tag_data)
 
-            return interleave((result, sim_tag_data)), msgs
+                return interleave((result, sim_tag_data)), msgs
 
         msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
         return result, msgs
@@ -109,7 +111,7 @@ class LBRadioTagRecordingElement(troi.Element):
 
         if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
-            similar_tags = similar_tags.random_item(25, 75, 2)
+            similar_tags = similar_tags.random_item(10, 75, 2)
             similar_tags = [ tag["similar_tag"] for tag in similar_tags ]
             msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""]
 

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -20,11 +20,12 @@ class LBRadioTagRecordingElement(troi.Element):
 
     TAG_THRESHOLD_MAPPING = {"easy": 3, "medium": 2, "hard": 1}
 
-    def __init__(self, tags, operator="and", mode="easy"):
+    def __init__(self, tags, operator="and", mode="easy", include_similar_tags=True):
         troi.Element.__init__(self)
         self.tags = tags
         self.operator = operator
         self.mode = mode
+        self.include_similar_tags = include_similar_tags
 
     def inputs(self):
         return []
@@ -78,7 +79,7 @@ class LBRadioTagRecordingElement(troi.Element):
         msgs = [ ]
         start, stop = self.local_storage["modes"]["easy"]
 
-        msgs = [f"tag: using seed tag(s): {self.tags} only"]
+        msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
         return tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT), msgs
 
     def select_recordings_on_medium(self, tag_data):
@@ -87,7 +88,7 @@ class LBRadioTagRecordingElement(troi.Element):
         start, stop = self.local_storage["modes"]["medium"]
         result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
 
-        if len(self.tags) == 1:
+        if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
             similar_tag = similar_tags.random_item(0, 50, 1)["similar_tag"]
             msgs = [f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."]
@@ -97,7 +98,7 @@ class LBRadioTagRecordingElement(troi.Element):
 
             return interleave((result, sim_tag_data)), msgs
 
-        msgs = ("tag: using seed tags: {self.tags} only")
+        msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
         return result, msgs
 
     def select_recordings_on_hard(self, tag_data):
@@ -106,7 +107,7 @@ class LBRadioTagRecordingElement(troi.Element):
         start, stop = self.local_storage["modes"]["hard"]
         result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
 
-        if len(self.tags) == 1:
+        if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
             similar_tags = similar_tags.random_item(25, 75, 2)
             similar_tags = [ tag["similar_tag"] for tag in similar_tags ]
@@ -117,7 +118,7 @@ class LBRadioTagRecordingElement(troi.Element):
 
             return interleave((result, sim_tag_data)), msgs
 
-        msgs = ("tag: using seed tags: {self.tags} only")
+        msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
         return result, msgs
 
     def read(self, entities):

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -6,6 +6,7 @@ import requests
 from troi import Recording
 from troi.splitter import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
+from troi.utils import interleave
 
 
 class LBRadioTagRecordingElement(troi.Element):
@@ -17,7 +18,7 @@ class LBRadioTagRecordingElement(troi.Element):
     EASY_MODE_RELEASE_GROUP_MIN_TAG_COUNT = 4
     MEDIUM_MODE_ARTIST_MIN_TAG_COUNT = 4
 
-    TAG_THRESHOLD_MAPPING = { "easy": 3, "medium": 2, "hard": 1 }
+    TAG_THRESHOLD_MAPPING = {"easy": 3, "medium": 2, "hard": 1}
 
     def __init__(self, tags, operator="and", mode="easy"):
         troi.Element.__init__(self)
@@ -53,144 +54,71 @@ class LBRadioTagRecordingElement(troi.Element):
 
         return dict(r.json())
 
-    def collect_recordings(self, recordings, tag_data, entity, min_tag_count=None):
-        """ 
-            This function takes a list of recordings already collected (could be empty),
-            the tag_data from the LB tag endpoint and an entity (artist, release-group, recording)
-            and a minimum_tag_count that will be used to select recordings from the tag_data.
-
-            Selected recordings will be added to the recordings and return as the first
-            item in a tuple, with the second item being a boolean if the list is not full. 
-            (and processing can stop).
+    def fetch_similar_tags(self, tag):
+        """
+            Fetch similar tags from LB
         """
 
-        if min_tag_count is None:
-            candidates = tag_data[entity]
-        else:
-            candidates = []
-            for rec in tag_data[entity]:
-                if rec["tag_count"] >= min_tag_count:
-                    candidates.append(rec)
+        r = requests.post("https://datasets.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
+        if r.status_code != 200:
+            raise RuntimeError(f"Cannot fetch similar tags. {r.text}")
 
-        while len(recordings) < self.NUM_RECORDINGS_TO_COLLECT and len(candidates) > 0:
-            recordings.append(candidates.pop(randint(0, len(candidates) - 1)))
+        return plist(r.json())
 
-        return recordings
+    def flatten_tag_data(self, tag_data):
 
-    def get_lowest_tag_count(self, highest_tag_count):
-        """ Given a highest tag count, return the lower bound for the tag_count based on how many tags exist."""
+        flat_data = tag_data["recording"]
+        flat_data.extend(tag_data["release-group"])
+        flat_data.extend(tag_data["artist"])
 
-        if highest_tag_count <= 1:
-            return highest_tag_count + 1  # This effectively means no tags will be collected
+        return plist(sorted(flat_data, key=lambda f: f["percent"], reverse=True))
 
-        if highest_tag_count <= 3:
-            return highest_tag_count - 1  # use only the highest tagged recordings
+    def select_recordings_on_easy(self, tag_data):
 
-        if highest_tag_count <= 5:
-            return highest_tag_count - 2
+        msgs = [ ]
+        start, stop = self.local_storage["modes"]["easy"]
 
-        if highest_tag_count <= 8:
-            return highest_tag_count - 3
+        msgs = [f"tag: using seed tag(s): {self.tags} only"]
+        return tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT), msgs
 
-        return highest_tag_count // 2
+    def select_recordings_on_medium(self, tag_data):
 
-    def select_recordings_on_easy(self, recordings, tag_data, tag_count):
-        try:
-            highest_tag_count = tag_data["recording"][0]["tag_count"]
-        except IndexError:
-            highest_tag_count = 0
+        msgs = [ ]
+        start, stop = self.local_storage["modes"]["medium"]
+        result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
 
-        if highest_tag_count > 0:
-            tag_count_text = f", highest tag count for easy mode is {highest_tag_count}"
-        else:
-            tag_count_text = ""
-        msg = f"{tag_data['count']['recording']:,} recordings tagged with '{', '.join(self.tags)}'{tag_count_text}"
-        self.local_storage["user_feedback"].append(msg)
+        if len(self.tags) == 1:
+            similar_tags = self.fetch_similar_tags(self.tags[0])
+            similar_tag = similar_tags.random_item(0, 50, 1)["similar_tag"]
+            msgs = [f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."]
 
-        recordings = self.collect_recordings(recordings, tag_data, "recording")
-        if len(recordings) < self.MIN_RECORDINGS_EASY:
-            lowest_tag_count = self.get_lowest_tag_count(highest_tag_count)
-            for tag_count in range(highest_tag_count, lowest_tag_count, -1):
-                recordings, canididate_count = self.collect_recordings(recordings,
-                                                                       tag_data,
-                                                                       "release-group",
-                                                                       min_tag_count=tag_count)
-                if len(recordings) >= self.NUM_RECORDINGS_TO_COLLECT:
-                    break
+            sim_tag_data = self.fetch_tag_data([similar_tag], "OR", 1)
+            sim_tag_data = self.flatten_tag_data(sim_tag_data)
 
-            if len(recordings) < self.MIN_RECORDINGS_EASY:
-                msg = "tag '%s' generated too few recordings for easy mode." % ", ".join(self.tags)
-                recordings = self.collect_recordings(recordings, tag_data, "release-group")
-                if len(recordings) >= self.MIN_RECORDINGS_MEDIUM:
-                    msg += " Try medium mode instead."
-                self.local_storage["user_feedback"].append(msg)
+            return interleave((result, sim_tag_data)), msgs
 
-                recordings = []
+        msgs = ("tag: using seed tags: {self.tags} only")
+        return result, msgs
 
-        return recordings
+    def select_recordings_on_hard(self, tag_data):
 
-    def select_recordings_on_medium(self, recordings, tag_data, tag_count):
-        try:
-            highest_tag_count = tag_data["release-group"][0]["tag_count"]
-        except IndexError:
-            highest_tag_count = 0
+        msgs = [ ]
+        start, stop = self.local_storage["modes"]["hard"]
+        result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
 
-        if highest_tag_count > 0:
-            tag_count_text = f", highest tag count for medium mode is {highest_tag_count}"
-        else:
-            tag_count_text = ""
-        msg = f"At least {tag_data['count']['release-group']:,} recordings on releases and release-groups tagged with '{', '.join(self.tags)}'{tag_count_text}"
+        if len(self.tags) == 1:
+            similar_tags = self.fetch_similar_tags(self.tags[0])
+            similar_tags = similar_tags.random_item(25, 75, 2)
+            similar_tags = [ tag["similar_tag"] for tag in similar_tags ]
+            msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""]
 
-        self.local_storage["user_feedback"].append(msg)
+            sim_tag_data = self.fetch_tag_data(similar_tags, "OR", 1)
+            sim_tag_data = self.flatten_tag_data(sim_tag_data)
 
-        recordings = self.collect_recordings(recordings, tag_data, "release-group")
-        if len(recordings) < self.MIN_RECORDINGS_MEDIUM:
-            lowest_tag_count = self.get_lowest_tag_count(highest_tag_count)
-            for tag_count in range(highest_tag_count, lowest_tag_count, -1):
-                recordings = self.collect_recordings(recordings, tag_data, "artist", tag_count)
-                if len(recordings) >= self.NUM_RECORDINGS_TO_COLLECT:
-                    break
+            return interleave((result, sim_tag_data)), msgs
 
-            if len(recordings) < self.MIN_RECORDINGS_MEDIUM:
-                # Check to see if there are tagged recordings we can use
-                recording_count = len(recordings)
-                recordings = self.collect_recordings(recordings, tag_data, "recording")
-                if len(recordings) > recording_count:
-                    self.local_storage["user_feedback"].append("Stole some tagged recordings, since they were going to waste.")
-                if len(recordings) < self.MIN_RECORDINGS_MEDIUM:
-                    self.local_storage["user_feedback"].append("tag '%s' generated too few recordings for medium mode." %
-                                                               ", ".join(self.tags))
-                    recordings = []
-
-        return recordings
-
-    def select_recordings_on_hard(self, recordings, tag_data, tag_count):
-        try:
-            highest_tag_count = tag_data["artist"][0]["tag_count"]
-        except IndexError:
-            highest_tag_count = 0
-
-        if highest_tag_count > 0:
-            tag_count_text = f", highest tag count for hard mode is {highest_tag_count}"
-        else:
-            tag_count_text = ""
-
-        msg = f"At least {tag_data['count']['artist']:,} recordings by artists tagged with '{', '.join(self.tags)}'{tag_count_text}"
-        self.local_storage["user_feedback"].append(msg)
-
-        recordings= self.collect_recordings(recordings, tag_data, "artist")
-        if len(recordings) < self.MIN_RECORDINGS_HARD:
-            # Check to see if the medium mode could produce something
-            recordings= self.collect_recordings(recordings, tag_data, "release-group")
-            if len(recordings) >= self.MIN_RECORDINGS_MEDIUM:
-                self.local_storage["user_feedback"].append(
-                    "tag '%s' generated too few recordings for hard mode. Try medium mode instead." % ", ".join(self.tags))
-            else:
-                self.local_storage["user_feedback"].append("tag '%s' generated too few recordings for hard mode." %
-                                                           ", ".join(self.tags))
-            recordings = []
-
-        return recordings
+        msgs = ("tag: using seed tags: {self.tags} only")
+        return result, msgs
 
     def read(self, entities):
 
@@ -200,17 +128,18 @@ class LBRadioTagRecordingElement(troi.Element):
             f'tag{"" if len(self.tags) == 1 else "s"} {", ".join(self.tags)}')
 
         tag_data = self.fetch_tag_data(self.tags, self.operator, min_tag_count)
+        tag_data = self.flatten_tag_data(tag_data)
 
-        # Now that we've fetched the tag data, depending on mode, start collecting recordings from it. The idea
-        # is to start on recordings for easy mode, release-group for medium and artist for hard mode. If not enough
-        # recordings are collected, descend one level and attempt to collect more.
         recordings = plist()
         if self.mode == "easy":
-            recordings = self.select_recordings_on_easy(recordings, tag_data, min_tag_count)
+            recordings, feedback = self.select_recordings_on_easy(tag_data)
         elif self.mode == "medium":
-            recordings = self.select_recordings_on_medium(recordings, tag_data, min_tag_count)
+            recordings, feedback = self.select_recordings_on_medium(tag_data)
         else:
-            recordings = self.select_recordings_on_hard(recordings, tag_data, min_tag_count)
+            recordings, feedback = self.select_recordings_on_hard(tag_data)
+
+        for msg in feedback:
+            self.local_storage["user_feedback"].append(msg)
 
         # Convert results into recordings
         results = []

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -34,12 +34,8 @@ class LBRadioTagRecordingElement(troi.Element):
             Fetch the tag data from the LB API and return it as a dict.
         """
 
-        if self.mode == "easy":
-            start, stop = 0, 50
-        elif self.mode == "medium":
-            start, stop = 25, 75
-        else:
-            start, stop = 50, 100
+        # Fetch our mode ranges
+        start, stop = self.local_storage["modes"][self.mode]
 
         data = {
             "condition": operator,

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -68,9 +68,9 @@ class LBRadioTagRecordingElement(troi.Element):
 
     def flatten_tag_data(self, tag_data):
 
-        flat_data = tag_data["recording"]
-        flat_data.extend(tag_data["release-group"])
-        flat_data.extend(tag_data["artist"])
+        flat_data = list(tag_data["recording"])
+        flat_data.extend(list(tag_data["release-group"]))
+        flat_data.extend(list(tag_data["artist"]))
 
         return plist(sorted(flat_data, key=lambda f: f["percent"], reverse=True))
 
@@ -109,18 +109,39 @@ class LBRadioTagRecordingElement(troi.Element):
         start, stop = self.local_storage["modes"]["hard"]
         result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
 
+        start, stop = 10, 50 
         if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
-            similar_tags = similar_tags.random_item(10, 75, 2)
+            if len(similar_tags[start:stop]) > 2:
+                while True:
+                    selected_tags = similar_tags.random_item(10, 50, 2)
+                    if selected_tags[0] == selected_tags[1]:
+                        print("same tag selected!")
+                        continue
+
+                    break
+                similar_tags = selected_tags
+            else:
+                similar_tags = similar_tags[start:stop]
+
             similar_tags = [ tag["similar_tag"] for tag in similar_tags ]
-            msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""]
 
-            sim_tag_data = self.fetch_tag_data(similar_tags, "OR", 1)
-            sim_tag_data = self.flatten_tag_data(sim_tag_data)
+            if len(similar_tags) > 0:
+                sim_tag_data = self.fetch_tag_data((self.tags[0], similar_tags[0]), "AND", 1)
+                sim_tag_data = self.flatten_tag_data(sim_tag_data)
+            
+                if len(similar_tags) > 1:
+                    sim_tag_data_2 = self.fetch_tag_data((self.tags[0], similar_tags[1]), "AND", 1)
+                    sim_tag_data_2 = self.flatten_tag_data(sim_tag_data_2)
+                    msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""]
+                else:
+                    msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tags[0]}'."""]
+                    sim_tag_data_2 = []
 
-            return interleave((result, sim_tag_data)), msgs
+                return interleave((result, sim_tag_data, sim_tag_data_2)), msgs
+        else:
+            msgs = [f"""tag: using only seed tag '{self.tags[0]}'."""]
 
-        msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
         return result, msgs
 
     def read(self, entities):

--- a/troi/splitter.py
+++ b/troi/splitter.py
@@ -177,6 +177,9 @@ class plist(list):
     """
 
     def _get_index(self, percent):
+        if len(self) == 0:
+            return None
+
         if percent is not None:
             if isinstance(percent, int):
                 if percent < 0 or percent > 100:

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -75,7 +75,21 @@ def recursively_update_dict(source, overrides):
 
 
 def interleave(lists):
-    """ Return a list with all items from the given lists. Stops when the shortest list end is reached. """
+    """ Return a list with all items from the given lists."""
 
-    return [val for tup in zip(*lists) for val in tup]
+    result = []
+
+    while True:
+        added = False
+        for l in lists:
+            try:
+                result.append(l.pop(0))
+                added = True
+            except IndexError:
+                pass
+
+        if not added:
+            break
+
+    return result
 

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -73,3 +73,9 @@ def recursively_update_dict(source, overrides):
             source[key] = overrides[key]
     return source
 
+
+def interleave(lists):
+    """ Return a list with all items from the given lists. Stops when the shortest list end is reached. """
+
+    return [val for tup in zip(*lists) for val in tup]
+


### PR DESCRIPTION
This PR improves the functionality of rag radio using similar tags for medium and hard mode. The addition of similar tags can be overridden with the nosim option. Other smaller tweaks to how the tag radio works were made (adjusting percent ranges, requiring minimum tag counts).

Finally add a troi.py file, which feels like it has been missing for a while.

The similar tags dataset is currently hosted on wolf, so that will need its own PR and release into labs API; once that is done,  I will open a new PR to start using the new production data.