### PR TITLE
Move LB radio tag similarity call to point to labs API

### DIFF
--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -60,7 +60,7 @@ class LBRadioTagRecordingElement(troi.Element):
             Fetch similar tags from LB
         """
 
-        r = requests.post("https://datasets.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
+        r = requests.post("https://labs.api.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
         if r.status_code != 200:
             raise RuntimeError(f"Cannot fetch similar tags. {r.text}")
 


### PR DESCRIPTION
This PR is the last step required to move tag similarity into production by pointing troi to it.