### PR TITLE
Do not emit an album key in JSPF if we don't have album info.

### DIFF
--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -59,7 +59,8 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None):
             artist_mbids = [str(mbid) for mbid in e.artist.mbids or []]
             track["creator"] = e.artist.name if e.artist else ""
 
-        track["album"] = e.release.name if e.release else ""
+        if e.release is not None and e.release.name != "":
+            track["album"] = e.release.name
         track["title"] = e.name
         track["identifier"] = "https://musicbrainz.org/recording/" + str(e.mbid)
         if artist_mbids:


### PR DESCRIPTION
If the key exists, but is empty LB will refuse to accept that as a listen. So not emitting the album key when we dont have an album fixes this.