### PR TITLE
LB-1395: Fix JSPF track identifier to be a list of strings

### DIFF
--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -60,7 +60,7 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None):
             track["creator"] = e.artist.name if e.artist else ""
 
         track["title"] = e.name
-        track["identifier"] = "https://musicbrainz.org/recording/" + str(e.mbid)
+        track["identifier"] = ["https://musicbrainz.org/recording/" + str(e.mbid)]
         if artist_mbids:
             track["extension"] = {
                 PLAYLIST_TRACK_EXTENSION_URI: {
@@ -89,7 +89,16 @@ def _deserialize_from_jspf(data) -> Playlist:
     recordings = []
 
     for track in data["track"]:
-        recording = Recording(name=track["title"], mbid=track["identifier"].split("/")[-1])
+        identifier = track["identifier"]
+        if isinstance(track["identifier"], str):
+            identifier = [identifier]
+        mbid = None
+        for id in identifier:
+            if id.startswith("https://musicbrainz.org/recording/") or id.startswith("http://musicbrainz.org/recording/"):
+                mbid = id.split("/")[-1]
+                break
+
+        recording = Recording(name=track["title"], mbid=mbid)
         if track.get("creator"):
             artist = Artist(name=track["creator"])
             extension = track["extension"][PLAYLIST_TRACK_EXTENSION_URI]


### PR DESCRIPTION
According to the XSPF/JSPF spec [1] a track can have an arbitrary number of identifiers. For JSPF this means the "identifier" field must be a list [2].

[1] https://xspf.org/spec#4112141112-identifier
[2] https://xspf.org/jspf

TODO:
- listenbrainz-server relies on the track identifier being a single string at multiple places
- Update the docs in https://musicbrainz.org/doc/jspf#track 