### PR TITLE
LB Radio Local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [ '*' ]
 
 permissions:
+  checks: write
   pull-requests: write
 
 jobs:

--- a/docs/lb_radio.rst
+++ b/docs/lb_radio.rst
@@ -86,14 +86,7 @@ Syntax Notes
 ------------
 
 The syntax attempts to be intuitive and simple, but it does have some limitations. The artist: entity has the most tricky restrictions
-because it should accept the full name of an artist. For latin character sets, the short form for an artist name can be used:
-
-::
-
-  artist:Blümchen
-  artist:The Knife
-
-But, if you need other unicode characters, the name must be enclosed by ():
+because it should accept the full name of an artist, so it must be wrapped in ():
 
 ::
 
@@ -101,22 +94,16 @@ But, if you need other unicode characters, the name must be enclosed by ():
 
 Furthermore, artist names must be spelled exactly as their appear in MusicBrainz.
 
-Tags have similar restrictions. If a tag you'd like to specify has no spaces or non-latin unicode characters you may use:
+Tags and comma seperated lists of tags have similar restrictions and must be enclosed by ():
 
 ::
 
-  tag:punk 
+  tag:(punk)
+
+A shorthand with #<tag> is allowed, as long as the tag does not contain spaces:
+::
+
   #punk
-
-But with spaces or non-latin unicode characters, wrap it in ():
-
-::
-
-  tag:(hip hop)
-
-::
-
-  tag:(あなたを決して裏切りません)
 
 
 Simple examples
@@ -124,14 +111,14 @@ Simple examples
 
 ::
 
-  artist:Rick Astley
+  artist:(Rick Astley)
 
 Create a single stream, from artist Rick Astley and similar artists. Artist names must be spelled here exactly as they are
 spelled in MusicBrainz. If for some reason the artist name is not recognized, specify an MBID instead. See below.
 
 ::
 
-  tag:rock:3 tag:pop:2
+  tag:(rock):3 tag:(pop):2
 
 Create two streams, one from tag "rock" contributing 3 parts of the recordings and one from tag "pop" contibuting 2 parts of the recordings.
 
@@ -205,13 +192,13 @@ More complex examples
 
 ::
 
-  artist:(pretty lights):3:easy tag:(trip hop):2 artist:morcheeba::nosim
+  artist:(pretty lights):3:easy tag:(trip hop):2 artist:(morcheeba)::nosim
 
 This prompt will play 3 parts from artist "Pretty Lights", 2 parts from the tag "trip hop" and 1 part from the artist "Morcheeba" with no
 tracks from similar artists.
 
 ::
 
-  tag:(deep house):2:medium tag:(metal):1:hard artist:blümchen:2:easy
+  tag:(deep house):2:medium tag:(metal):1:hard artist:(blümchen):2:easy
 
 This will play 2 parts from tag "deep house" on medium mode, 1 part from tag "metal" on hard mode and 2 parts from artists "Blümchen" on easy mode.

--- a/tests/musicbrainz/test_recording_lookup.py
+++ b/tests/musicbrainz/test_recording_lookup.py
@@ -62,7 +62,7 @@ class TestRecordingLookup(unittest.TestCase):
 
         assert len(entities) == 2
         assert entities[0].name == "Sour Times"
-        assert entities[0].length == 253000
+        assert entities[0].duration == 253000
         assert entities[0].artist.name == "Portishead"
         assert entities[0].artist.artist_credit_id == 65
         assert entities[0].mbid == "a96bf3b6-651d-49f4-9a89-eee27cecc18e"
@@ -70,7 +70,7 @@ class TestRecordingLookup(unittest.TestCase):
         assert entities[0].release.name == "Dummy"
 
         assert entities[1].name == "Blue Angel"
-        assert entities[1].length == 275333
+        assert entities[1].duration == 275333
         assert entities[1].artist.name == "Squirrel Nut Zippers"
         assert entities[1].artist.artist_credit_id == 11
         assert entities[1].mbid == "cfa47c9b-f12f-4f9c-a6da-22a9355d6125"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,17 +15,12 @@ class TestParser(unittest.TestCase):
 
         self.assertRaises(ParseError, parse, "wrong:57baa3c6-ee43-4db3-9e6a-50bbc9792ee4")
 
-        r = parse("artist:the knife")
+        r = parse("artist:(the knife)")
         assert r[0] == {"entity": "artist", "values": ["the knife"], "weight": 1, "opts": []}
 
         self.assertRaises(ParseError, parse, "artist:u2:nosim")
 
     def test_tags(self):
-        r = parse("t:abstract t:rock t:blues")
-        assert r[0] == {"entity": "tag", "values": ["abstract"], "weight": 1, "opts": []}
-        assert r[1] == {"entity": "tag", "values": ["rock"], "weight": 1, "opts": []}
-        assert r[2] == {"entity": "tag", "values": ["blues"], "weight": 1, "opts": []}
-
         r = parse("t:(abstract,rock,blues)")
         assert r[0] == {"entity": "tag", "values": ["abstract", "rock", "blues"], "weight": 1, "opts": []}
 
@@ -42,12 +37,6 @@ class TestParser(unittest.TestCase):
 
         r = parse("t:(r&b)")
         assert r[0] == {"entity": "tag", "values": ["r&b"], "weight": 1, "opts": []}
-
-        r = parse("t:r&b")
-        assert r[0] == {"entity": "tag", "values": ["r&b"], "weight": 1, "opts": []}
-
-        r = parse("t:blümchen")
-        assert r[0] == {"entity": "tag", "values": ["blümchen"], "weight": 1, "opts": []}
 
         r = parse("t:(blümchen)")
         assert r[0] == {"entity": "tag", "values": ["blümchen"], "weight": 1, "opts": []}
@@ -83,7 +72,7 @@ class TestParser(unittest.TestCase):
                           "a:57baa3c6-ee43-4db3-9e6a-50bbc9792ee4:1 a:f54ba4c6-12dd-4358-9136-c64ad89420c5:fussy")
         self.assertRaises(ParseError, parse, "a:57baa3c6-ee43-4db3-9e6a-50bbc9792ee4:1 a:f54ba4c6-12dd-4358-9136-c64ad89420c5:.5")
 
-        r = parse("a:portishead::easy")
+        r = parse("a:(portishead)::easy")
         assert r[0] == {"entity": "artist", "values": ["portishead"], "weight": 1, "opts": ["easy"]}
 
         r = parse("a:57baa3c6-ee43-4db3-9e6a-50bbc9792ee4::easy")

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -2,7 +2,6 @@ import unittest
 
 import requests_mock
 
-from troi.core import generate_playlist
 from troi.patch import Patch
 from troi import Recording, Element, Playlist
 from troi.tools.spotify_lookup import SPOTIFY_IDS_LOOKUP_URL
@@ -142,7 +141,7 @@ class TestSpotifySubmission(unittest.TestCase):
         )
         mock_requests.put(f"https://api.spotify.com/v1/playlists/{playlist_id}/tracks", json={"snapshot_id": "bar"})
 
-        playlist = generate_playlist(DummyPatch(), {
+        patch = DummyPatch({
             "min_recordings": 1,
             "spotify": {
                 "token": "spotify-auth-token",
@@ -153,6 +152,7 @@ class TestSpotifySubmission(unittest.TestCase):
             "name": "Test Export Playlist",
             "upload": True
         })
+        playlist = patch.generate_playlist()
 
         history = mock_requests.request_history
 

--- a/troi/__init__.py
+++ b/troi/__init__.py
@@ -263,10 +263,10 @@ class Recording(Entity):
     """
         The class that represents a recording.
     """
-    def __init__(self, name=None, mbid=None, msid=None, length=None, artist=None, release=None,
+    def __init__(self, name=None, mbid=None, msid=None, duration=None, artist=None, release=None,
                  ranking=None, year=None, spotify_id=None, musicbrainz=None, listenbrainz=None, acousticbrainz=None):
         Entity.__init__(self, ranking=ranking, musicbrainz=musicbrainz, listenbrainz=listenbrainz, acousticbrainz=acousticbrainz)
-        self.length = length # track length in ms
+        self.duration = duration # track duration in ms
         self.artist = artist
         self.release = release
         self.name = name

--- a/troi/core.py
+++ b/troi/core.py
@@ -9,123 +9,6 @@ import troi.playlist
 import troi.utils
 from troi.patch import Patch
 
-default_patch_args = dict(
-    debug=False,
-    echo=True,
-    save=False,
-    token=None,
-    upload=False,
-    args=None,
-    created_for=None,
-    name=None,
-    desc=None,
-    min_recordings=10,
-    spotify=None
-)
-
-
-def generate_playlist(patch: Patch, args: Dict):
-    """
-    Generate a playlist using a patch
-
-    The args parameter is a dict and may containt the following keys:
-
-    * debug: Print debug information or not
-    * print: This option causes the generated playlist to be printed to stdout.
-    * save: The save option causes the generated playlist to be saved to disk.
-    * token: Auth token to use when using the LB API. Required for submitting playlists to the server. See https://listenbrainz.org/profile to get your user token.
-    * upload: Whether or not to submit the finished playlist to the LB server. Token must be set for this to work.
-    * created-for: If this option is specified, it must give a valid user name and the TOKEN argument must specify a user who is whitelisted as a playlist bot at listenbrainz.org .
-    * name: Override the algorithms that generate a playlist name and use this name instead.
-    * desc: Override the algorithms that generate a playlist description and use this description instead.
-    * min-recordings: The minimum number of recordings that must be present in a playlist to consider it complete. If it doesn't have sufficient numbers of tracks, ignore the playlist and don't submit it. Default: Off, a playlist with at least one track will be considere complete.
-    * spotify: if present, attempt to submit the playlist to spotify as well. should be a dict and contain the spotify user id, spotify auth token with appropriate permissions, whether the playlist should be public, private or collaborative. it can also optionally have the existing urls to update playlists instead of creating new ones.
-
-    :param patch: the patch to run
-    :param args: the arguments to pass to the patch, may contain one of more of the following keys:
-
-    """
-
-    patch_args = {**default_patch_args, **args}
-    pipeline = patch.create(patch_args)
-    _set_element_patch(patch, pipeline)
-    try:
-        playlist = troi.playlist.PlaylistElement()
-        playlist.set_sources(pipeline)
-        print("Troi playlist generation starting...")
-        result = playlist.generate()
-
-        name = patch_args["name"]
-        if name:
-            playlist.playlists[0].name = name
-
-        desc = patch_args["desc"]
-        if desc:
-            playlist.playlists[0].descripton = desc
-
-        print("done.")
-    except troi.PipelineError as err:
-        print("Failed to generate playlist: %s" % err, file=sys.stderr)
-        return None
-
-    upload = patch_args["upload"]
-    token = patch_args["token"]
-    spotify = patch_args["spotify"]
-    if upload and not token and not spotify:
-        print("In order to upload a playlist, you must provide an auth token. Use option --token.")
-        return None
-
-    min_recordings = patch_args["min_recordings"]
-    if min_recordings is not None and \
-            (len(playlist.playlists) == 0 or len(playlist.playlists[0].recordings) < min_recordings):
-        print("Playlist does not have at least %d recordings, stopping." % min_recordings)
-        return None
-
-    save = patch_args["save"]
-    if result is not None and spotify and upload:
-        for url, _ in playlist.submit_to_spotify(
-                spotify["user_id"],
-                spotify["token"],
-                spotify["is_public"],
-                spotify["is_collaborative"],
-                spotify.get("existing_urls", [])
-        ):
-            print("Submitted playlist to spotify: %s" % url)
-
-    created_for = patch_args["created_for"]
-    if result is not None and token and upload:
-        for url, _ in playlist.submit(token, created_for):
-            print("Submitted playlist: %s" % url)
-
-    if result is not None and save:
-        playlist.save()
-        print("playlist saved.")
-
-    echo = patch_args["echo"]
-    if result is not None and (echo or not token):
-        print()
-        playlist.print()
-
-    if not echo and not save and not token:
-        if result is None:
-            print("Patch executed successfully.")
-        elif len(playlist.playlists) == 0:
-            print("No playlists were generated. :(")
-        elif len(playlist.playlists) == 1:
-            print("A playlist with %d tracks was generated." % len(playlist.playlists[0].recordings))
-        else:
-            print("%d playlists were generated." % len(playlist.playlists))
-
-    return playlist
-
-def _set_element_patch(patch, pipeline):
-    """ 
-        Go through the pipeline, setting the patch objects for each Element
-    """
-    pipeline.set_patch_object(patch)
-    for src in pipeline.sources:
-        _set_element_patch(patch, src)
-
 
 
 def list_patches():
@@ -149,8 +32,7 @@ def patch_info(patch):
 
     patches = troi.utils.discover_patches()
     if patch not in patches:
-        print("Cannot load patch '%s'. Use the list command to get a list of available patches." % patch,
-              file=sys.stderr)
+        print("Cannot load patch '%s'. Use the list command to get a list of available patches." % patch, file=sys.stderr)
         sys.exit(1)
 
     apatch = patches[patch]
@@ -165,6 +47,7 @@ def convert_patch_to_command(patch):
 
         :param patch: the patch to get info for.
     """
+
     def f(**data):
         return data
 

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -19,7 +19,7 @@ class UserRecordingRecommendationsElement(Element):
 
     MAX_RECORDINGS_TO_FETCH = 2000
 
-    def __init__(self, user_name, artist_type, count=25, offset=0, auth_token=None):
+    def __init__(self, user_name, artist_type, count=25, offset=0):
         super().__init__()
         self.client = liblistenbrainz.ListenBrainz()
         if auth_token:

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -22,8 +22,6 @@ class UserRecordingRecommendationsElement(Element):
     def __init__(self, user_name, artist_type, count=25, offset=0):
         super().__init__()
         self.client = liblistenbrainz.ListenBrainz()
-        if auth_token:
-            self.client.set_auth_token(auth_token)
         self.user_name = user_name
         self.count = count
         self.offset = offset

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -99,7 +99,7 @@ class RecordingLookupElement(Element):
                                     mbid=row["release_mbid"])
 
             r.name = row['recording_name']
-            r.length = row['length']
+            r.duration = row['length']
             r.mbid = row['recording_mbid']
 
             r.listenbrainz["canonical_recording_mbid"] = row["canonical_recording_mbid"]

--- a/troi/parse_prompt.py
+++ b/troi/parse_prompt.py
@@ -52,20 +52,12 @@ def build_parser():
                  + pp.Suppress(pp.Literal(':')) \
                  + pp.Group(uuid, aslist=True) \
                  + optional
-    element_text = artist_element  \
-                 + pp.Suppress(pp.Literal(':')) \
-                 + pp.Group(text, aslist=True) \
-                 + optional
     element_paren_text = artist_element \
                        + pp.Suppress(pp.Literal(':')) \
                        + pp.Group(paren_text, aslist=True) \
                        + optional
 
     # Define tag element
-    element_tag = tag_element \
-                + pp.Suppress(pp.Literal(':')) \
-                + pp.Group(tag, aslist=True) \
-                + optional
     element_paren_tag = tag_element \
                       + pp.Suppress(pp.Literal(':')) \
                       + pp.Group(paren_text, aslist=True) \
@@ -105,8 +97,8 @@ def build_parser():
 
     # Finally combine all elements into one, starting with the shortest/simplest elements and getting more
     # complex
-    elements = element_tag | element_tag_shortcut | element_uuid | element_paren_recs | element_collection | element_playlist | \
-               element_text | element_paren_stats | element_paren_recs | element_recs | element_stats | \
+    elements = element_tag_shortcut | element_uuid | element_paren_recs | element_collection | element_playlist | \
+               element_paren_stats | element_paren_recs | element_recs | element_stats | \
                element_paren_text | element_paren_tag | element_tag_paren_shortcut
 
     # All of the above was to parse one single term, now allow the stats to define more than one if they want

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -1,10 +1,26 @@
 import logging
+import troi
 from abc import ABC, abstractmethod
+
+from troi.recording_search_service import RecordingSearchByTagService, RecordingSearchByArtistService
+
+default_patch_args = dict(debug=False,
+                          echo=True,
+                          save=False,
+                          token=None,
+                          upload=False,
+                          args=None,
+                          created_for=None,
+                          name=None,
+                          desc=None,
+                          min_recordings=10,
+                          spotify=None)
 
 
 class Patch(ABC):
 
-    def __init__(self, debug=False):
+    def __init__(self, args, debug=False):
+        self.args = args
         if debug:
             level = logging.DEBUG
         else:
@@ -14,6 +30,15 @@ class Patch(ABC):
 
         # Dict used for local storage
         self.local_storage = {}
+
+        self.patch_args = {**default_patch_args, **args}
+        self.pipeline = self.create(self.patch_args)
+        self._set_element_patch(self.pipeline)
+
+        # Setup extensible services
+        self.services = {}
+        self.register_service(RecordingSearchByTagService())
+        self.register_service(RecordingSearchByArtistService())
 
     def log(self, msg):
         '''
@@ -79,6 +104,23 @@ class Patch(ABC):
         """
         return None
 
+    def register_service(self, service):
+        """
+            Register a new service that can provide services to troi patches.
+
+            Only one service can be registered for any given service slug at a time. The most
+            recently registered service will be use for the next playlist generation.
+        """
+        self.services[service.slug] = service
+
+    def get_service(self, slug):
+        """
+           Given a service slug, return the class registered for this service. 
+
+           Raises IndexError if no such service is registered.
+        """
+        return self.services[slug]
+
     def post_process(self):
         """
             This function is called once the pipeline has produced its playlist, just before the Playlist object is created.
@@ -95,3 +137,96 @@ class Patch(ABC):
             return self.local_storage["user_feedback"]
         except KeyError:
             return []
+
+    def generate_playlist(self):
+        """
+        Generate a playlist 
+
+        The args parameter is a dict and may containt the following keys:
+
+        * debug: Print debug information or not
+        * print: This option causes the generated playlist to be printed to stdout.
+        * save: The save option causes the generated playlist to be saved to disk.
+        * token: Auth token to use when using the LB API. Required for submitting playlists to the server. See https://listenbrainz.org/profile to get your user token.
+        * upload: Whether or not to submit the finished playlist to the LB server. Token must be set for this to work.
+        * created-for: If this option is specified, it must give a valid user name and the TOKEN argument must specify a user who is whitelisted as a playlist bot at listenbrainz.org .
+        * name: Override the algorithms that generate a playlist name and use this name instead.
+        * desc: Override the algorithms that generate a playlist description and use this description instead.
+        * min-recordings: The minimum number of recordings that must be present in a playlist to consider it complete. If it doesn't have sufficient numbers of tracks, ignore the playlist and don't submit it. Default: Off, a playlist with at least one track will be considere complete.
+        * spotify: if present, attempt to submit the playlist to spotify as well. should be a dict and contain the spotify user id, spotify auth token with appropriate permissions, whether the playlist should be public, private or collaborative. it can also optionally have the existing urls to update playlists instead of creating new ones.
+
+        :param args: the arguments to pass to the patch, may contain one of more of the following keys:
+
+        """
+
+        try:
+            playlist = troi.playlist.PlaylistElement()
+            playlist.set_sources(self.pipeline)
+            print("Troi playlist generation starting...")
+            result = playlist.generate()
+
+            name = self.patch_args["name"]
+            if name:
+                playlist.playlists[0].name = name
+
+            desc = self.patch_args["desc"]
+            if desc:
+                playlist.playlists[0].descripton = desc
+
+            print("done.")
+        except troi.PipelineError as err:
+            print("Failed to generate playlist: %s" % err, file=sys.stderr)
+            return None
+
+        upload = self.patch_args["upload"]
+        token = self.patch_args["token"]
+        spotify = self.patch_args["spotify"]
+        if upload and not token and not spotify:
+            print("In order to upload a playlist, you must provide an auth token. Use option --token.")
+            return None
+
+        min_recordings = self.patch_args["min_recordings"]
+        if min_recordings is not None and \
+                (len(playlist.playlists) == 0 or len(playlist.playlists[0].recordings) < min_recordings):
+            print("Playlist does not have at least %d recordings, stopping." % min_recordings)
+            return None
+
+        save = self.patch_args["save"]
+        if result is not None and spotify and upload:
+            for url, _ in playlist.submit_to_spotify(spotify["user_id"], spotify["token"], spotify["is_public"],
+                                                     spotify["is_collaborative"], spotify.get("existing_urls", [])):
+                print("Submitted playlist to spotify: %s" % url)
+
+        created_for = self.patch_args["created_for"]
+        if result is not None and token and upload:
+            for url, _ in playlist.submit(token, created_for):
+                print("Submitted playlist: %s" % url)
+
+        if result is not None and save:
+            playlist.save()
+            print("playlist saved.")
+
+        echo = self.patch_args["echo"]
+        if result is not None and (echo or not token):
+            print()
+            playlist.print()
+
+        if not echo and not save and not token:
+            if result is None:
+                print("Patch executed successfully.")
+            elif len(playlist.playlists) == 0:
+                print("No playlists were generated. :(")
+            elif len(playlist.playlists) == 1:
+                print("A playlist with %d tracks was generated." % len(playlist.playlists[0].recordings))
+            else:
+                print("%d playlists were generated." % len(playlist.playlists))
+
+        return playlist
+
+    def _set_element_patch(self, element):
+        """ 
+            Go through the pipeline, setting the patch objects for each Element
+        """
+        element.set_patch_object(self)
+        for src in element.sources:
+            self._set_element_patch(src)

--- a/troi/patches/area_random_recordings.py
+++ b/troi/patches/area_random_recordings.py
@@ -13,8 +13,8 @@ class AreaRandomRecordingsPatch(troi.patch.Patch):
 
     SERVER_URL = DEVELOPMENT_SERVER_URL + "/area-random-recordings/json"
 
-    def __init__(self, debug=False):
-        super().__init__(debug)
+    def __init__(self, args, debug=False):
+        super().__init__(args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import requests
 from urllib.parse import quote
 
+import troi.patch
 import troi.filters
 import troi.listenbrainz.feedback
 import troi.listenbrainz.listens
@@ -30,10 +31,12 @@ class LBRadioPatch(troi.patch.Patch):
     # If the user specifies no time_range, default to this one
     DEFAULT_TIME_RANGE = "month"
 
-    def __init__(self, debug=False):
-        super().__init__(debug)
+    def __init__(self, args, debug=False):
         self.artist_mbids = []
         self.mode = None
+
+        # Remember, the create function for this class will be called in the super() init.
+        super().__init__(args, debug)
 
     @staticmethod
     def inputs():
@@ -77,12 +80,16 @@ class LBRadioPatch(troi.patch.Patch):
 
         err_msg = f"Artist {artist_name} could not be looked up. Please use exact spelling."
 
-        r = requests.get(f"https://musicbrainz.org/ws/2/artist?query={quote(artist_name)}&fmt=json")
+        r = requests.get(
+            f"https://musicbrainz.org/ws/2/artist?query={quote(artist_name)}&fmt=json"
+        )
         if r.status_code == 404:
             raise RuntimeError(err_msg)
 
         if r.status_code != 200:
-            raise RuntimeError(f"Could not resolve artist name {artist_name}. Error {r.status_code}")
+            raise RuntimeError(
+                f"Could not resolve artist name {artist_name}. Error {r.status_code}"
+            )
 
         data = r.json()
         try:
@@ -107,15 +114,21 @@ class LBRadioPatch(troi.patch.Patch):
             raise RuntimeError(f"cannot parse prompt: '{err}'")
 
         if self.mode not in ("easy", "medium", "hard"):
-            raise RuntimeError("Argument mode must be one one easy, medium or hard.")
+            raise RuntimeError(
+                "Argument mode must be one one easy, medium or hard.")
 
         # Lookup artist names embedded in the prompt
         for element in prompt_elements:
-            if element["entity"] == "artist" and isinstance(element["values"][0], str):
-                element["values"][0] = UUID(self.lookup_artist_name(element["values"][0]))
+            if element["entity"] == "artist" and isinstance(
+                    element["values"][0], str):
+                element["values"][0] = UUID(
+                    self.lookup_artist_name(element["values"][0]))
 
         # Save descriptions to local storage
-        self.local_storage["data_cache"] = {"element-descriptions": [], "prompt": self.prompt}
+        self.local_storage["data_cache"] = {
+            "element-descriptions": [],
+            "prompt": self.prompt
+        }
         self.local_storage["user_feedback"] = []
 
         weights = [e["weight"] for e in prompt_elements]
@@ -138,44 +151,66 @@ class LBRadioPatch(troi.patch.Patch):
                 start, stop = 33, 66
             else:
                 start, stop = 66, 100
-            self.local_storage["modes"] = {"easy": (0, 33), "medium": (33, 66), "hard": (66, 100)}
+            self.local_storage["modes"] = {
+                "easy": (0, 33),
+                "medium": (33, 66),
+                "hard": (66, 100)
+            }
 
             if element["entity"] == "artist":
                 include_sim = False if "nosim" in element["opts"] else True
-                source = LBRadioArtistRecordingElement(element["values"][0], mode=mode, include_similar_artists=include_sim)
+                source = LBRadioArtistRecordingElement(
+                    element["values"][0],
+                    mode=mode,
+                    include_similar_artists=include_sim)
 
             if element["entity"] == "tag":
                 include_sim = False if "nosim" in element["opts"] else True
-                source = LBRadioTagRecordingElement(element["values"], mode=mode, operator="and", include_similar_tags=include_sim)
-
-            if element["entity"] == "tag-or":
-                source = LBRadioTagRecordingElement(element["values"], mode=mode, operator="or")
+                operator = "or" if "or" in element["opts"] else "and"
+                source = LBRadioTagRecordingElement(
+                    element["values"],
+                    mode=mode,
+                    operator=operator,
+                    include_similar_tags=include_sim)
 
             if element["entity"] == "collection":
-                source = LBRadioCollectionRecordingElement(element["values"][0], mode=mode)
+                source = LBRadioCollectionRecordingElement(
+                    element["values"][0], mode=mode)
 
             if element["entity"] == "playlist":
-                source = LBRadioPlaylistRecordingElement(element["values"][0], mode=mode)
+                source = LBRadioPlaylistRecordingElement(element["values"][0],
+                                                         mode=mode)
 
             if element["entity"] == "stats":
                 if len(element["opts"]) == 0:
                     element["opts"].append(self.DEFAULT_TIME_RANGE)
                 if len(element["values"]) == 0:
-                    raise RuntimeError("user name cannot be blank for user entity. (at least not yet -- soon it will be)")
+                    raise RuntimeError(
+                        "user name cannot be blank for user entity. (at least not yet -- soon it will be)"
+                    )
                 if len(element["opts"]) != 1:
-                    raise RuntimeError("The user entity needs to define one time range option.")
-                source = LBRadioStatsRecordingElement(element["values"][0], mode=mode, time_range=element["opts"][0])
+                    raise RuntimeError(
+                        "The user entity needs to define one time range option."
+                    )
+                source = LBRadioStatsRecordingElement(
+                    element["values"][0],
+                    mode=mode,
+                    time_range=element["opts"][0])
 
             if element["entity"] == "recs":
                 if len(element["values"]) == 0:
-                    raise RuntimeError("user name cannot be blank for user entity. (at least not yet -- soon it will be)")
+                    raise RuntimeError(
+                        "user name cannot be blank for user entity. (at least not yet -- soon it will be)"
+                    )
                 if len(element["opts"]) == 0:
                     listened = "all"
                 else:
                     listened = element["opts"][0]
-                source = LBRadioRecommendationRecordingElement(element["values"][0], mode=mode, listened=listened)
+                source = LBRadioRecommendationRecordingElement(
+                    element["values"][0], mode=mode, listened=listened)
 
-            recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement()
+            recs_lookup = troi.musicbrainz.recording_lookup.RecordingLookupElement(
+            )
             recs_lookup.set_sources(source)
 
             hate_filter = troi.filters.HatedRecordingsFilterElement()
@@ -187,7 +222,9 @@ class LBRadioPatch(troi.patch.Patch):
         blend = WeighAndBlendRecordingsElement(weights, max_num_recordings=100)
         blend.set_sources(elements)
 
-        pl_maker = PlaylistMakerElement(patch_slug=self.slug(), max_num_recordings=TARGET_NUMBER_OF_RECORDINGS)
+        pl_maker = PlaylistMakerElement(
+            patch_slug=self.slug(),
+            max_num_recordings=TARGET_NUMBER_OF_RECORDINGS)
         pl_maker.set_sources(blend)
 
         return pl_maker
@@ -198,8 +235,10 @@ class LBRadioPatch(troi.patch.Patch):
         """
 
         prompt = self.local_storage["data_cache"]["prompt"]
-        names = ", ".join(self.local_storage["data_cache"]["element-descriptions"])
+        names = ", ".join(
+            self.local_storage["data_cache"]["element-descriptions"])
         name = f"LB Radio for {names} on {self.mode} mode"
-        desc = "Experimental ListenBrainz radio using %s mode, which was generated from this prompt: '%s'" % (self.mode, prompt)
+        desc = "Experimental ListenBrainz radio using %s mode, which was generated from this prompt: '%s'" % (
+            self.mode, prompt)
         self.local_storage["_playlist_name"] = name
         self.local_storage["_playlist_desc"] = desc

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -160,6 +160,8 @@ class LBRadioArtistRecordingElement(troi.Element):
             recordings = recs_plist.random_item(start, stop, self.max_top_recordings_per_artist)
 
             # Now tuck away the data for caching and interleaving
+            # The whole artist caching concept hasn't worked very well, and with future changes, it will likely go away.
+            # For now, ignore.
             #self.data_cache[artist["mbid"] + "_top_recordings"] = recordings
             artist["recordings"] = recordings
 

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -5,6 +5,7 @@ from troi import Recording, Artist
 from troi.splitter import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
 from troi.utils import interleave
+from troi.recording_search_service import RecordingSearchByArtistService
 
 OVERHYPED_SIMILAR_ARTISTS = [
     "b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d",  # The Beatles
@@ -73,26 +74,6 @@ class LBRadioArtistRecordingElement(troi.Element):
 
         return plist(sorted(artists, key=lambda a: a["score"], reverse=True))
 
-    def fetch_top_recordings(self, artist_mbid):
-        """
-            Given and artist_mbid, fetch top recordings for this artist and retun them in a plist.
-        """
-
-        r = requests.get("https://api.listenbrainz.org/1/popularity/top-recordings-for-artist", params={"artist_mbid": artist_mbid})
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch top artist recordings: {r.status_code} ({r.text})")
-
-        recordings = plist()
-        for recording in r.json():
-            artist = Artist(mbids=recording["artist_mbids"], name=recording["artist_name"])
-            recordings.append(
-                Recording(mbid=recording["recording_mbid"],
-                          name=recording["recording_name"],
-                          length=recording["length"],
-                          artist=artist))
-
-        return recordings
-
     def fetch_artist_names(self, artist_mbids):
         """
             Fetch artists names for a given list of artist_mbids 
@@ -112,6 +93,9 @@ class LBRadioArtistRecordingElement(troi.Element):
 
         self.data_cache = self.local_storage["data_cache"]
         artists = [{"mbid": self.artist_mbid}]
+
+        self.recording_search_by_artist = self.patch.get_service(
+            "recording-search-by-artist")
 
         # First, fetch similar artists if the user didn't override that.
         if self.include_similar_artists:
@@ -155,24 +139,28 @@ class LBRadioArtistRecordingElement(troi.Element):
             self.local_storage["user_feedback"].append(msg)
         self.data_cache["element-descriptions"].append("artist %s" % artists[0]["name"])
 
-        # Now collect recordings from the artist and similar artists and return an interleaved
-        # strem of recordings.
-        for i, artist in enumerate(artists):
-            if artist["mbid"] + "_top_recordings" in self.data_cache:
-                artist["recordings"] = self.data_cache[artist["mbid"] + "_top_recordings"]
-                continue
+        artist_mbids = [ artist["mbid"] for artist in artists ]
+        artist_mbids = list(set(artist_mbids))
+        artist_recordings = self.recording_search_by_artist.search(artist_mbids, start, stop, self.max_top_recordings_per_artist)
 
-            recs_plist = plist(self.fetch_top_recordings(artist["mbid"]))
+        # Now collect recordings from the artist and similar artists and return an interleaved
+        # stream of recordings.
+        for i, artist in enumerate(artists):
+
+            # TODO: This disables top recordings caching, which needs to be re-thought given the new approach
+            #if artist["mbid"] + "_top_recordings" in self.data_cache:
+            #    artist["recordings"] = self.data_cache[artist["mbid"] + "_top_recordings"]
+            #    continue
+
+            recs_plist = plist(artist_recordings[artist["mbid"]])
             if len(recs_plist) < 20:
                 self.local_storage["user_feedback"].append(
                     f"Artist {artist['name']} only has {'no' if len(recs_plist) == 0 else 'few'} top recordings.")
 
-            recordings = []
-            for recording in recs_plist.random_item(start, stop, self.max_top_recordings_per_artist):
-                recordings.append(recording)
+            recordings = recs_plist.random_item(start, stop, self.max_top_recordings_per_artist)
 
             # Now tuck away the data for caching and interleaving
-            self.data_cache[artist["mbid"] + "_top_recordings"] = recordings
+            #self.data_cache[artist["mbid"] + "_top_recordings"] = recordings
             artist["recordings"] = recordings
 
         return interleave([a["recordings"] for a in artists])

--- a/troi/patches/lb_radio_classes/blend.py
+++ b/troi/patches/lb_radio_classes/blend.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import troi
 from random import randint
 from troi import Recording
@@ -44,10 +45,11 @@ class WeighAndBlendRecordingsElement(troi.Element):
         A source that has a weight of 2 will be chosen 2 times more often than a source with weight 1.
     """
 
-    def __init__(self, weights, max_num_recordings=TARGET_NUMBER_OF_RECORDINGS):
+    def __init__(self, weights, max_num_recordings=TARGET_NUMBER_OF_RECORDINGS, max_artist_occurrence=None):
         troi.Element.__init__(self)
         self.weights = weights
         self.max_num_recordings = max_num_recordings
+        self.max_artist_occurrence = max_artist_occurrence
 
     def inputs(self):
         return [Recording]
@@ -77,6 +79,7 @@ class WeighAndBlendRecordingsElement(troi.Element):
 
         # This still allows sequential tracks to be from the same artists. I'll wait for feedback to see if this
         # is a problem.
+        artist_counts = defaultdict(int)
         dedup_set = set()
         while True:
             r = randint(0, total)
@@ -89,8 +92,14 @@ class WeighAndBlendRecordingsElement(troi.Element):
                                 total_available -= 1
                                 continue
 
+                            if self.max_artist_occurrence is not None and artist_counts[",".join(
+                                    rec.artist.mbids)] == self.max_artist_occurrence:
+                                total_available -= 1
+                                continue
+
                             recordings.append(rec)
                             dedup_set.add(rec.mbid)
+                            artist_counts[",".join(rec.artist.mbids)] += 1
                         break
 
             if len(recordings) >= self.max_num_recordings or len(recordings) == total_available:

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -13,6 +13,7 @@ from troi.utils import interleave
 # - Review use of ranges.
 # - Review having to invert the tag ranges
 # - Fix artist search to not just pick the bottom of the top, but really fetch the bottom
+# - Review or remove artist caching from artist element
 
 class LBRadioTagRecordingElement(troi.Element):
 

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -8,10 +8,14 @@ from troi.splitter import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
 from troi.utils import interleave
 
+# TODO:
+# - Review use of ranges.
+# - Review having to invert the tag ranges
+# - Fix artist search to not just pick the bottom of the top, but really fetch the bottom
 
 class LBRadioTagRecordingElement(troi.Element):
 
-    NUM_RECORDINGS_TO_COLLECT = TARGET_NUMBER_OF_RECORDINGS * 2
+    NUM_RECORDINGS_TO_COLLECT = TARGET_NUMBER_OF_RECORDINGS * 4
     MIN_RECORDINGS_EASY = NUM_RECORDINGS_TO_COLLECT
     MIN_RECORDINGS_MEDIUM = 50
     MIN_RECORDINGS_HARD = 25
@@ -20,7 +24,11 @@ class LBRadioTagRecordingElement(troi.Element):
 
     TAG_THRESHOLD_MAPPING = {"easy": 3, "medium": 2, "hard": 1}
 
-    def __init__(self, tags, operator="and", mode="easy", include_similar_tags=True):
+    def __init__(self,
+                 tags,
+                 operator="and",
+                 mode="easy",
+                 include_similar_tags=True):
         troi.Element.__init__(self)
         self.tags = tags
         self.operator = operator
@@ -33,141 +41,154 @@ class LBRadioTagRecordingElement(troi.Element):
     def outputs(self):
         return [Recording]
 
-    def fetch_tag_data(self, tags, operator, min_tag_count):
-        """
-            Fetch the tag data from the LB API and return it as a dict.
-        """
-
-        # Fetch our mode ranges
-        start, stop = self.local_storage["modes"][self.mode]
-
-        data = {
-            "condition": operator,
-            "count": self.NUM_RECORDINGS_TO_COLLECT,
-            "begin_percent": start,
-            "end_percent": stop,
-            "tag": tags,
-            "min_tag_count": min_tag_count
-        }
-        r = requests.get("https://api.listenbrainz.org/1/lb-radio/tags", params=data)
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch recordings for tags. {r.text}")
-
-        return dict(r.json())
-
     def fetch_similar_tags(self, tag):
         """
             Fetch similar tags from LB
         """
 
-        r = requests.post("https://labs.api.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
+        r = requests.post(
+            "https://labs.api.listenbrainz.org/tag-similarity/json",
+            json=[{
+                "tag": tag
+            }])
         if r.status_code != 200:
             raise RuntimeError(f"Cannot fetch similar tags. {r.text}")
 
         return plist(r.json())
 
-    def flatten_tag_data(self, tag_data):
+    def invert_for_tag_search(self, startstop):
+        return tuple(
+            (1.0 - (startstop[1] / 100.), 1.0 - (startstop[0] / 100.0)))
 
-        flat_data = list(tag_data["recording"])
-        flat_data.extend(list(tag_data["release-group"]))
-        flat_data.extend(list(tag_data["artist"]))
+    def select_recordings_on_easy(self):
 
-        return plist(sorted(flat_data, key=lambda f: f["percent"], reverse=True))
+        msgs = []
+        start, stop = self.invert_for_tag_search(
+            self.local_storage["modes"]["easy"])
+        tag_data = self.recording_search_by_tag.search(
+            self.tags, self.operator, start, stop,
+            self.NUM_RECORDINGS_TO_COLLECT)
 
-    def select_recordings_on_easy(self, tag_data):
-
-        msgs = [ ]
-        start, stop = self.local_storage["modes"]["easy"]
+        if len(tag_data) > self.NUM_RECORDINGS_TO_COLLECT:
+            tag_data = tag_data.random_item(start, stop,
+                                            self.NUM_RECORDINGS_TO_COLLECT)
 
         msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
-        return tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT), msgs
+        return tag_data, msgs
 
-    def select_recordings_on_medium(self, tag_data):
+    def select_recordings_on_medium(self):
 
-        msgs = [ ]
-        start, stop = self.local_storage["modes"]["medium"]
-        result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
+        msgs = []
+        start, stop = self.invert_for_tag_search(
+            self.local_storage["modes"]["medium"])
+        tag_data = self.recording_search_by_tag.search(
+            self.tags, self.operator, start, stop,
+            self.NUM_RECORDINGS_TO_COLLECT)
+
+        if len(tag_data) > self.NUM_RECORDINGS_TO_COLLECT:
+            tag_data = tag_data.random_item(start, stop,
+                                          self.NUM_RECORDINGS_TO_COLLECT)
 
         if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
             similar_tag = similar_tags.random_item(0, 50, 1)
             if similar_tag is not None:
                 similar_tag = similar_tag["similar_tag"]
-                msgs = [f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."]
+                msgs = [
+                    f"tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tag}'."
+                ]
 
-                sim_tag_data = self.fetch_tag_data([similar_tag], "OR", 1)
-                sim_tag_data = self.flatten_tag_data(sim_tag_data)
+                sim_tag_data = self.recording_search_by_tag.search(
+                    [similar_tag], "OR", start, stop,
+                    self.NUM_RECORDINGS_TO_COLLECT)
 
-                return interleave((result, sim_tag_data)), msgs
+                if len(sim_tag_data) > self.NUM_RECORDINGS_TO_COLLECT:
+                    sim_tag_data = sim_tag_data.random_item(
+                        start, stop, self.NUM_RECORDINGS_TO_COLLECT)
+
+                return interleave((tag_data, sim_tag_data)), msgs
 
         msgs = [f"""tag: using seed tags: '{ "', '".join(self.tags)}' only"""]
-        return result, msgs
+        return tag_data, msgs
 
-    def select_recordings_on_hard(self, tag_data):
+    def select_recordings_on_hard(self):
 
-        msgs = [ ]
-        start, stop = self.local_storage["modes"]["hard"]
-        result = tag_data.random_item(start, stop, self.NUM_RECORDINGS_TO_COLLECT)
+        msgs = []
+        start, stop = self.invert_for_tag_search(
+            self.local_storage["modes"]["hard"])
 
-        start, stop = 10, 50 
+        tag_data = self.recording_search_by_tag.search(
+            self.tags, self.operator, start, stop,
+            self.NUM_RECORDINGS_TO_COLLECT)
+        if len(tag_data) > self.NUM_RECORDINGS_TO_COLLECT:
+            tag_data = tag_data.random_item(start, stop,
+                                            self.NUM_RECORDINGS_TO_COLLECT)
+
+        sim_start, sim_stop = 10, 50
         if len(self.tags) == 1 and self.include_similar_tags:
             similar_tags = self.fetch_similar_tags(self.tags[0])
-            if len(similar_tags[start:stop]) > 2:
+            if len(similar_tags[sim_start:sim_stop]) > 2:
                 while True:
                     selected_tags = similar_tags.random_item(10, 50, 2)
                     if selected_tags[0] == selected_tags[1]:
-                        print("same tag selected!")
                         continue
 
                     break
                 similar_tags = selected_tags
             else:
-                similar_tags = similar_tags[start:stop]
+                similar_tags = similar_tags[sim_start:sim_stop]
 
-            similar_tags = [ tag["similar_tag"] for tag in similar_tags ]
+            similar_tags = [tag["similar_tag"] for tag in similar_tags]
 
             if len(similar_tags) > 0:
-                sim_tag_data = self.fetch_tag_data((self.tags[0], similar_tags[0]), "AND", 1)
-                sim_tag_data = self.flatten_tag_data(sim_tag_data)
-            
+                sim_tag_data = self.recording_search_by_tag.search(
+                    (self.tags[0], similar_tags[0]), "AND", start, stop,
+                    self.NUM_RECORDINGS_TO_COLLECT)
+                if len(sim_tag_data) > self.NUM_RECORDINGS_TO_COLLECT:
+                    sim_tag_data = sim_tag_data.random_item(
+                        start, stop, self.NUM_RECORDINGS_TO_COLLECT)
+
                 if len(similar_tags) > 1:
-                    sim_tag_data_2 = self.fetch_tag_data((self.tags[0], similar_tags[1]), "AND", 1)
-                    sim_tag_data_2 = self.flatten_tag_data(sim_tag_data_2)
-                    msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""]
+                    sim_tag_data_2 = self.recording_search_by_tag.search(
+                        (self.tags[0], similar_tags[1]), "AND", start, stop,
+                        self.NUM_RECORDINGS_TO_COLLECT)
+
+                    if len(sim_tag_data_2) > self.NUM_RECORDINGS_TO_COLLECT:
+                        sim_tag_data_2 = sim_tag_data_2.random_item(
+                            start, stop, self.NUM_RECORDINGS_TO_COLLECT)
+
+                    msgs = [
+                        f"""tag: using seed tag '{self.tags[0]}' and similar tags '{"', '".join(similar_tags)}'."""
+                    ]
                 else:
-                    msgs = [f"""tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tags[0]}'."""]
+                    msgs = [
+                        f"""tag: using seed tag '{self.tags[0]}' and similar tag '{similar_tags[0]}'."""
+                    ]
                     sim_tag_data_2 = []
 
-                return interleave((result, sim_tag_data, sim_tag_data_2)), msgs
+                return interleave((tag_data, sim_tag_data, sim_tag_data_2)), msgs
         else:
             msgs = [f"""tag: using only seed tag '{self.tags[0]}'."""]
 
-        return result, msgs
+        return tag_data, msgs
 
     def read(self, entities):
 
         min_tag_count = self.TAG_THRESHOLD_MAPPING[self.mode]
+        self.recording_search_by_tag = self.patch.get_service(
+            "recording-search-by-tag")
 
         self.local_storage["data_cache"]["element-descriptions"].append(
             f'tag{"" if len(self.tags) == 1 else "s"} {", ".join(self.tags)}')
 
-        tag_data = self.fetch_tag_data(self.tags, self.operator, min_tag_count)
-        tag_data = self.flatten_tag_data(tag_data)
-
-        recordings = plist()
         if self.mode == "easy":
-            recordings, feedback = self.select_recordings_on_easy(tag_data)
+            recordings, feedback = self.select_recordings_on_easy()
         elif self.mode == "medium":
-            recordings, feedback = self.select_recordings_on_medium(tag_data)
+            recordings, feedback = self.select_recordings_on_medium()
         else:
-            recordings, feedback = self.select_recordings_on_hard(tag_data)
+            recordings, feedback = self.select_recordings_on_hard()
 
         for msg in feedback:
             self.local_storage["user_feedback"].append(msg)
 
-        # Convert results into recordings
-        results = []
-        for rec in recordings:
-            results.append(Recording(mbid=rec["recording_mbid"]))
-
-        return results
+        return recordings

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -8,7 +8,8 @@ from troi.splitter import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
 from troi.utils import interleave
 
-# TODO:
+# TODO improvements for post troi/liblistenbrainz/content-resolve packaging work, but before the next
+#      release of LB Radio for lb-server:
 # - Review use of ranges.
 # - Review having to invert the tag ranges
 # - Fix artist search to not just pick the bottom of the top, but really fetch the bottom

--- a/troi/patches/periodic_jams.py
+++ b/troi/patches/periodic_jams.py
@@ -46,8 +46,8 @@ class PeriodicJamsPatch(troi.patch.Patch):
 
     JAM_TYPES = ("daily-jams", "weekly-jams", "weekly-exploration")
 
-    def __init__(self, debug=False):
-        super().__init__(debug)
+    def __init__(self, args, debug=False):
+        super().__init__(args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/patches/playlist_from_mbids.py
+++ b/troi/patches/playlist_from_mbids.py
@@ -9,8 +9,8 @@ class PlaylistFromMBIDsPatch(troi.patch.Patch):
     """
     """
 
-    def __init__(self, debug=False):
-        troi.patch.Patch.__init__(self, debug)
+    def __init__(self, args, debug=False):
+        troi.patch.Patch.__init__(self, args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/patches/recs_to_playlist.py
+++ b/troi/patches/recs_to_playlist.py
@@ -58,8 +58,8 @@ class RecommendationsToPlaylistPatch(troi.patch.Patch):
         See below for description
     """
 
-    def __init__(self, debug=False):
-        troi.patch.Patch.__init__(self, debug)
+    def __init__(self, args, debug=False):
+        troi.patch.Patch.__init__(self, args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/patches/top_discoveries_for_year.py
+++ b/troi/patches/top_discoveries_for_year.py
@@ -25,8 +25,8 @@ class TopDiscoveries(troi.patch.Patch):
               </p>
            """
 
-    def __init__(self, debug=False):
-        troi.patch.Patch.__init__(self, debug)
+    def __init__(self, args, debug=False):
+        troi.patch.Patch.__init__(self, args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/patches/top_missed_recordings_for_year.py
+++ b/troi/patches/top_missed_recordings_for_year.py
@@ -80,8 +80,8 @@ class TopMissedTracksPatch(troi.patch.Patch):
               </p>
            """
 
-    def __init__(self, debug=False, max_num_recordings=50):
-        troi.patch.Patch.__init__(self, debug)
+    def __init__(self, args, debug=False, max_num_recordings=50):
+        troi.patch.Patch.__init__(self, args, debug)
         self.max_num_recordings = max_num_recordings
 
     @staticmethod

--- a/troi/patches/weekly_flashback_jams.py
+++ b/troi/patches/weekly_flashback_jams.py
@@ -63,8 +63,8 @@ class WeeklyFlashbackJams(troi.patch.Patch):
         See below for description
     """
 
-    def __init__(self, debug=False):
-        troi.patch.Patch.__init__(self, debug)
+    def __init__(self, args, debug=False):
+        troi.patch.Patch.__init__(self, args, debug)
 
     @staticmethod
     def inputs():

--- a/troi/recording_search_service.py
+++ b/troi/recording_search_service.py
@@ -1,0 +1,88 @@
+from abc import abstractmethod
+
+import requests
+
+from troi import Recording, Artist
+from troi.service import Service
+from troi.splitter import plist
+
+# NOTES FOR LB API improvements:
+# Tags:
+#    - flatten tag data for simplicity
+#    - use series of tighter random spots to speed up or searches for popular tags
+# Artist:
+#    - Support percent based popular track lookups and move logic to server
+
+
+class RecordingSearchByTagService(Service):
+
+    SLUG = "recording-search-by-tag"
+
+    def __init__(self):
+        super().__init__(self.SLUG)
+
+    def search(self, tags, operator, begin_percent, end_percent, num_recordings):
+        """
+            Fetch the tag data from the LB API and return it as a dict.
+        """
+
+        data = {
+            "condition": operator,
+            "count": num_recordings,
+            "begin_percent": begin_percent,
+            "end_percent": end_percent,
+            "tag": tags,
+            "min_tag_count": 1
+        }
+        r = requests.get("https://api.listenbrainz.org/1/lb-radio/tags", params=data)
+        if r.status_code != 200:
+            raise RuntimeError(f"Cannot fetch recordings for tags. {r.text}")
+
+        recordings = []
+        for rec in self.flatten_tag_data(dict(r.json())):
+            recordings.append(Recording(mbid=rec["recording_mbid"]))
+
+        return plist(recordings)
+
+    def flatten_tag_data(self, tag_data):
+
+        flat_data = list(tag_data["recording"])
+        flat_data.extend(list(tag_data["release-group"]))
+        flat_data.extend(list(tag_data["artist"]))
+
+        return sorted(flat_data, key=lambda f: f["percent"], reverse=True)
+
+
+class RecordingSearchByArtistService(Service):
+
+    SLUG = "recording-search-by-artist"
+
+    def __init__(self):
+        super().__init__(self.SLUG)
+
+    def search(self, artists, begin_percent, end_percent, num_recordings):
+        """
+            Fetch the artist data from the LB API and return it as a dict.
+
+            NOTE: This search is poor -- it should span all recordings by an artist not, just the top ones!
+        """
+
+        artists_recordings = {}
+        for artist_mbid in artists:
+            params={"artist_mbid": artist_mbid}
+            r = requests.get("https://api.listenbrainz.org/1/popularity/top-recordings-for-artist", params={"artist_mbid": artist_mbid})
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch top artist recordings: {r.status_code} ({r.text})")
+
+            recordings = plist()
+            for recording in r.json():
+                artist = Artist(mbids=recording["artist_mbids"], name=recording["artist_name"])
+                recordings.append(
+                    Recording(mbid=recording["recording_mbid"],
+                              name=recording["recording_name"],
+                              duration=recording["length"],
+                              artist=artist))
+
+            artists_recordings[artist_mbid] = recordings.random_item(begin_percent, end_percent, num_recordings)
+
+        return artists_recordings

--- a/troi/service.py
+++ b/troi/service.py
@@ -1,0 +1,18 @@
+class Service:
+    """
+        Services allow troi users to provide local versions of key search functions
+        so that both global (e.g. MusicBrainz) and local search contexts can be used.
+        
+        Downstream users will be able to provide localized version of search functions
+        to provide lists of Recordings that meet certain requirements for playlist inclusion.
+
+        Only one service can be registered for any given service slug at a time. The most
+        recently registered service will be use for the next playlist generation.
+    """
+
+    def __init__(self, slug):
+        self._slug = slug
+
+    @property
+    def slug(self):
+        return self._slug

--- a/troi/utils.py
+++ b/troi/utils.py
@@ -4,7 +4,6 @@ import os
 import traceback
 import sys
 
-import troi.patch
 
 
 def discover_patches():
@@ -27,6 +26,8 @@ def discover_patches_from_dir(module_path, patch_dir, add_dot=False):
         If add_dot = True, add . to the sys.path and then remove it before this function exists.
     """
 
+    # This is here to avoid a circular import
+    import troi.patch
     if add_dot:
         sys.path.append(".")
 


### PR DESCRIPTION
This PR extends troi in the following way:

- Create a registry for services that allow local resolution of content: artist_search and tag_search. By doing a local search against a local collection, we avoid the problems of having to resolve a playlist, which can often destroy that playlist. This required some refactoring of the artist and tag elements.
- Refactor how playlists are generated to be a little more streamlined.
- Add support for subsonic_ids in the musicbrainz metadata.
- Simplify the syntax of LB-Radio (disallow text not wrapped in () )
- Minor other bits of refactoring.