### PR TITLE
Jspf cleanup

### DIFF
--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -30,7 +30,7 @@ class LBRadioPlaylistRecordingElement(troi.Element):
     def read(self, entities):
 
         # Fetch the playlist
-        r = requests.get(f"https://test-api.listenbrainz.org/1/playlist/{self.mbid}")
+        r = requests.get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
         if r.status_code == 404:
             raise RuntimeError(f"Cannot find playlist {self.mbid}.")
         if r.status_code != 200:

--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -30,7 +30,7 @@ class LBRadioPlaylistRecordingElement(troi.Element):
     def read(self, entities):
 
         # Fetch the playlist
-        r = requests.get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
+        r = requests.get(f"https://test-api.listenbrainz.org/1/playlist/{self.mbid}")
         if r.status_code == 404:
             raise RuntimeError(f"Cannot find playlist {self.mbid}.")
         if r.status_code != 200:
@@ -40,7 +40,7 @@ class LBRadioPlaylistRecordingElement(troi.Element):
         self.local_storage["data_cache"]["element-descriptions"].append(f"playlist {self.mbid}")
 
         # Fetch the recordings, then shuffle
-        mbid_list = [r["identifier"][34:] for r in r.json()["playlist"]["track"]]
+        mbid_list = [r["identifier"][0][34:] for r in r.json()["playlist"]["track"]]
         shuffle(mbid_list)
 
         # Select and convert the first n MBIDs into Recordings

--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -40,7 +40,7 @@ class LBRadioPlaylistRecordingElement(troi.Element):
         self.local_storage["data_cache"]["element-descriptions"].append(f"playlist {self.mbid}")
 
         # Fetch the recordings, then shuffle
-        mbid_list = [r["identifier"][0][34:] for r in r.json()["playlist"]["track"]]
+        mbid_list = [r["identifier"][34:] for r in r.json()["playlist"]["track"]]
         shuffle(mbid_list)
 
         # Select and convert the first n MBIDs into Recordings

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -63,7 +63,7 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None):
             track["creator"] = e.artist_credit.name if e.artist_credit else ""
 
         track["title"] = e.name
-        track["identifier"] = ["https://musicbrainz.org/recording/" + str(e.mbid)]
+        track["identifier"] = "https://musicbrainz.org/recording/" + str(e.mbid)
 
         loc = e.musicbrainz.get("filename", None)
         if loc is not None:
@@ -109,20 +109,21 @@ def _deserialize_from_jspf(data) -> Playlist:
 
     for track in data["track"]:
         identifier = track["identifier"]
-        if isinstance(track["identifier"], str):
-            identifier = [identifier]
-        mbid = None
-        for id in identifier:
-            if id.startswith("https://musicbrainz.org/recording/") or id.startswith("http://musicbrainz.org/recording/"):
-                mbid = id.split("/")[-1]
-                break
+
+        if identifier.startswith("https://musicbrainz.org/recording/") or \
+                identifier.startswith("http://musicbrainz.org/recording/"):
+            mbid = identifier.split("/")[-1]
+        else:
+            mbid = None
 
         recording = Recording(name=track["title"], mbid=mbid)
         if track.get("creator"):
             extension = track["extension"][PLAYLIST_TRACK_EXTENSION_URI]
             if extension.get("artist_identifiers"):
                 artist_mbids = [url.split("/")[-1] for url in extension.get("artist_identifiers")]
-                artists = [ Artist(mbid) for mbid in artist_mbids ]
+                artists = [Artist(mbid) for mbid in artist_mbids]
+            else:
+                artists = None
             recording.artist_credit = ArtistCredit(name=track["creator"], artists=artists)
 
         if track.get("album"):
@@ -429,7 +430,7 @@ class PlaylistMakerElement(Element):
         :param desc: The description of the playlist
         :param patch-slug: The patch slug (URL-safe short name) of the patch that created the playlist. Optional.
         :param max_num_recordings: The maximum number of recordings to have in the playlist. Extras are discarded. Optional argument, and the default is to keep all recordings
-        :param max_artist_occurence: The number of times and artist is allowed to appear in the playlist. Any recordings that exceed this count ared discarded. Optional, default is to keep all recordings.
+        :param max_artist_occurrence: The number of times and artist is allowed to appear in the playlist. Any recordings that exceed this count ared discarded. Optional, default is to keep all recordings.
         :param shuffle: If True, the playlist will be shuffled before being truncated. Optional. Default: False
         :param is_april_first: If True, do something very sneaky. Default: False.
     '''

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -63,7 +63,7 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None):
             track["creator"] = e.artist_credit.name if e.artist_credit else ""
 
         track["title"] = e.name
-        track["identifier"] = "https://musicbrainz.org/recording/" + str(e.mbid)
+        track["identifier"] = ["https://musicbrainz.org/recording/" + str(e.mbid)]
 
         loc = e.musicbrainz.get("filename", None)
         if loc is not None:
@@ -108,7 +108,16 @@ def _deserialize_from_jspf(data) -> Playlist:
     recordings = []
 
     for track in data["track"]:
-        recording = Recording(name=track["title"], mbid=track["identifier"].split("/")[-1])
+        identifier = track["identifier"]
+        if isinstance(track["identifier"], str):
+            identifier = [identifier]
+        mbid = None
+        for id in identifier:
+            if id.startswith("https://musicbrainz.org/recording/") or id.startswith("http://musicbrainz.org/recording/"):
+                mbid = id.split("/")[-1]
+                break
+
+        recording = Recording(name=track["title"], mbid=mbid)
         if track.get("creator"):
             artist = Artist(name=track["creator"])
             extension = track["extension"][PLAYLIST_TRACK_EXTENSION_URI]

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -25,11 +25,6 @@ PLAYLIST_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#playlist"
 PLAYLIST_TRACK_EXTENSION_URI = "https://musicbrainz.org/doc/jspf#track"
 SUBSONIC_URI_PREFIX = "https://subsonic.org/entity/song/"
 
-# TODO: When resolving a playlist, insert "location" into existing playlist, don't create a new one
-#       And recording lookup needs to be replace with metadata lookup. retire the labs API endpoint!
-#       Artist.mbids is totatlly stupid (see ^^). We need [artists] with "join_phrase" in musicbrainz hash.
-#       All this for the next PR.
-
 
 def _serialize_to_jspf(playlist, created_for=None, track_count=None):
     """
@@ -51,8 +46,7 @@ def _serialize_to_jspf(playlist, created_for=None, track_count=None):
         data["annotation"] = playlist.description
 
     if created_for:
-        # TODO: This element is in the wrong location!
-        data["created_for"] = created_for
+        data["extension"][PLAYLIST_EXTENSION_URI]["created_for"] = created_for
 
     if playlist.additional_metadata:
         data["extension"][PLAYLIST_EXTENSION_URI]["additional_metadata"] = playlist.additional_metadata

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -6,7 +6,7 @@ import json
 import requests
 import spotipy
 
-from troi import Recording, Playlist, PipelineError, Element, Artist, Release
+from troi import Recording, Playlist, PipelineError, Element, Artist, ArtistCredit, Release
 from troi.operations import is_homogeneous
 from troi.print_recording import PrintRecordingList
 from troi.tools.spotify_lookup import submit_to_spotify
@@ -119,12 +119,11 @@ def _deserialize_from_jspf(data) -> Playlist:
 
         recording = Recording(name=track["title"], mbid=mbid)
         if track.get("creator"):
-            artist = Artist(name=track["creator"])
             extension = track["extension"][PLAYLIST_TRACK_EXTENSION_URI]
             if extension.get("artist_identifiers"):
                 artist_mbids = [url.split("/")[-1] for url in extension.get("artist_identifiers")]
-                artist.mbids = artist_mbids
-            recording.artist = artist
+                artists = [ Artist(mbid) for mbid in artist_mbids ]
+            recording.artist_credit = ArtistCredit(name=track["creator"], artists=artists)
 
         if track.get("album"):
             recording.release = Release(name=track["album"])


### PR DESCRIPTION
This PR fixes some problems with JSPF serialization:

    The created_for element should be part of the extension.
    track identifier should be a list not a string.

This PR must be released WITH the troi PR of the same branch name! That PR needs to be updated after this PR is merged and released.