### PR TITLE
A new Patch for importing playlists from Spotify

### DIFF
--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -4,6 +4,7 @@ from troi import Playlist
 from troi.patch import Patch
 from troi.playlist import RecordingsFromMusicServiceElement, PlaylistMakerElement
 from troi.musicbrainz.recording_lookup import RecordingLookupElement
+from troi.tools.spotify_lookup import get_tracks_from_playlist
 
 
 class ImportPlaylistPatch(Patch):
@@ -38,8 +39,10 @@ class ImportPlaylistPatch(Patch):
 
         ms_token = inputs["ms_token"]
         playlist_id = inputs["playlist_id"]
+        
+        _, name, desc = get_tracks_from_playlist(ms_token, playlist_id)
 
-        source, name, desc = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id)
+        source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id)
         
         rec_lookup = RecordingLookupElement()
         rec_lookup.set_sources(source)

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -4,7 +4,8 @@ from troi import Playlist
 from troi.patch import Patch
 from troi.playlist import RecordingsFromMusicServiceElement, PlaylistMakerElement
 from troi.musicbrainz.recording_lookup import RecordingLookupElement
-from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist, get_tracks_from_apple_playlist
+from troi.tools.apple_lookup import get_tracks_from_apple_playlist
+from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist
 
 
 class ImportPlaylistPatch(Patch):
@@ -54,9 +55,9 @@ class ImportPlaylistPatch(Patch):
         
         # this one only used to get track name and desc
         if music_service == "spotify":
-            _, name, desc = get_tracks_from_spotify_playlist(ms_token, playlist_id)
+            tracks, name, desc = get_tracks_from_spotify_playlist(ms_token, playlist_id)
         elif music_service == "apple_music":
-            _, name, desc = get_tracks_from_apple_playlist(ms_token, apple_user_token, playlist_id)
+            tracks, name, desc = get_tracks_from_apple_playlist(ms_token, apple_user_token, playlist_id)
 
         source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id, music_service=music_service, apple_user_token=apple_user_token)
         

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -1,0 +1,53 @@
+import json
+
+from troi import Playlist
+from troi.patch import Patch
+from troi.playlist import RecordingsFromMusicServiceElement, PlaylistMakerElement
+from troi.musicbrainz.recording_lookup import RecordingLookupElement
+
+
+class ImportPlaylistPatch(Patch):
+
+    @staticmethod
+    def inputs():
+        """
+        A patch that retrieves an existing playlist from Spotify for use in Troi.
+
+        \b
+        MS_TOKEN is the music service token from which the playlist is retrieved. For now, only Spotify tokens are accepted. 
+        PLAYLIST_ID is the playlist id to retrieve the tracks from it.
+        LB_TOKEN is the listenbrainz auth token used to upload the playlist.
+        """
+        return [
+            {"type": "argument", "args": ["ms_token"], "kwargs": {"required": False}},
+            {"type": "argument", "args": ["playlist_id"], "kwargs": {"required": False}},
+            {"type": "argument", "args": ["lb_token"], "kwargs": {"required": False}}
+        ]
+
+    @staticmethod
+    def outputs():
+        return [Playlist]
+
+    @staticmethod
+    def slug():
+        return "import-playlist"
+
+    @staticmethod
+    def description():
+        return "Retrieve a playlist from the Spotify"
+
+    def create(self, inputs):
+
+        ms_token = inputs["ms_token"]
+        playlist_id = inputs["playlist_id"]
+
+        token = inputs.get("lb_token")
+        source = RecordingsFromMusicServiceElement(ms_token=ms_token, playlist_id=playlist_id, token=token)
+        
+        rec_lookup = RecordingLookupElement()
+        rec_lookup.set_sources(source)
+
+        pl_maker = PlaylistMakerElement("Playlist made from MBIDs", "", patch_slug=self.slug())
+        pl_maker.set_sources(rec_lookup)
+
+        return pl_maker

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -14,14 +14,12 @@ class ImportPlaylistPatch(Patch):
         A patch that retrieves an existing playlist from Spotify for use in Troi.
 
         \b
-        MS_TOKEN is the music service token from which the playlist is retrieved. For now, only Spotify tokens are accepted. 
+        TOKEN is the music service token from which the playlist is retrieved. For now, only Spotify tokens are accepted. 
         PLAYLIST_ID is the playlist id to retrieve the tracks from it.
-        LB_TOKEN is the listenbrainz auth token used to upload the playlist.
         """
         return [
-            {"type": "argument", "args": ["ms_token"], "kwargs": {"required": False}},
+            {"type": "argument", "args": ["token"], "kwargs": {"required": False}},
             {"type": "argument", "args": ["playlist_id"], "kwargs": {"required": False}},
-            {"type": "argument", "args": ["lb_token"], "kwargs": {"required": False}}
         ]
 
     @staticmethod
@@ -38,11 +36,11 @@ class ImportPlaylistPatch(Patch):
 
     def create(self, inputs):
 
-        ms_token = inputs["ms_token"]
+        token = inputs["token"]
         playlist_id = inputs["playlist_id"]
 
         token = inputs.get("lb_token")
-        source = RecordingsFromMusicServiceElement(ms_token=ms_token, playlist_id=playlist_id, token=token)
+        source = RecordingsFromMusicServiceElement(token=token, playlist_id=playlist_id)
         
         rec_lookup = RecordingLookupElement()
         rec_lookup.set_sources(source)

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -14,11 +14,11 @@ class ImportPlaylistPatch(Patch):
         A patch that retrieves an existing playlist from Spotify for use in Troi.
 
         \b
-        TOKEN is the music service token from which the playlist is retrieved. For now, only Spotify tokens are accepted. 
+        MS_TOKEN is the music service token from which the playlist is retrieved. For now, only Spotify tokens are accepted. 
         PLAYLIST_ID is the playlist id to retrieve the tracks from it.
         """
         return [
-            {"type": "argument", "args": ["token"], "kwargs": {"required": False}},
+            {"type": "argument", "args": ["ms_token"], "kwargs": {"required": False}},
             {"type": "argument", "args": ["playlist_id"], "kwargs": {"required": False}},
         ]
 
@@ -36,11 +36,10 @@ class ImportPlaylistPatch(Patch):
 
     def create(self, inputs):
 
-        token = inputs["token"]
+        ms_token = inputs["ms_token"]
         playlist_id = inputs["playlist_id"]
 
-        token = inputs.get("lb_token")
-        source = RecordingsFromMusicServiceElement(token=token, playlist_id=playlist_id)
+        source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id)
         
         rec_lookup = RecordingLookupElement()
         rec_lookup.set_sources(source)

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -39,12 +39,12 @@ class ImportPlaylistPatch(Patch):
         ms_token = inputs["ms_token"]
         playlist_id = inputs["playlist_id"]
 
-        source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id)
+        source, name, desc = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id)
         
         rec_lookup = RecordingLookupElement()
         rec_lookup.set_sources(source)
 
-        pl_maker = PlaylistMakerElement("Playlist made from MBIDs", "", patch_slug=self.slug())
+        pl_maker = PlaylistMakerElement(name, desc, patch_slug=self.slug())
         pl_maker.set_sources(rec_lookup)
 
         return pl_maker

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -522,24 +522,20 @@ class PlaylistMakerElement(Element):
 
         return [playlist]
 
-#TODO: migrate to other file 
+
 class RecordingsFromMusicServiceElement(Element):
     """ Create a troi.Playlist entity from track and artist names."""
 
     def __init__(self, token=None, playlist_id=None):
-        # """
-        #     The caller must pass either playlist_mbid or the jspf itself, but not both.
-        #     Args:
-        #         playlist_mbid: mbid of the ListenBrainz playlist to be used for creating the playlist element
-        #         jspf: The actual JSPF for the playlist.
-        #         token: the listenbrainz auth token to fetch the playlist, only needed for private playlists
-        # """
+        """
+            Args:
+                playlist_id: id of the Spotify playlist to be used for creating the playlist element
+                token: the Spotify token to fetch the playlist tracks
+        """
         super().__init__()
         self.token = token
         self.playlist_id = playlist_id
 
-        # if self.jspf is not None and self.playlist_mbid is not None:
-        #     raise RuntimeError("Pass either jspf or playlist_mbid to PlaylistFromJSPFElement, not both.")
 
     @staticmethod
     def outputs():
@@ -553,7 +549,7 @@ class RecordingsFromMusicServiceElement(Element):
             for track in mbid_mapped_tracks:
                 if track is not None and "recording_mbid" in track:
                     recordings.append(Recording(mbid=track["recording_mbid"]))
-    
+
         return recordings
 
     

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -526,7 +526,7 @@ class PlaylistMakerElement(Element):
 class RecordingsFromMusicServiceElement(Element):
     """ Create a troi.Playlist entity from track and artist names."""
 
-    def __init__(self, ms_token=None, playlist_id=None, token=None):
+    def __init__(self, token=None, playlist_id=None):
         # """
         #     The caller must pass either playlist_mbid or the jspf itself, but not both.
         #     Args:
@@ -535,7 +535,6 @@ class RecordingsFromMusicServiceElement(Element):
         #         token: the listenbrainz auth token to fetch the playlist, only needed for private playlists
         # """
         super().__init__()
-        self.ms_token = ms_token
         self.token = token
         self.playlist_id = playlist_id
 
@@ -549,7 +548,7 @@ class RecordingsFromMusicServiceElement(Element):
     def read(self, inputs):
         recordings = []
 
-        mbid_mapped_tracks = music_service_tracks_to_mbid(self.ms_token, self.playlist_id)
+        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id)
         if mbid_mapped_tracks:
             for track in mbid_mapped_tracks:
                 if track is not None and "recording_mbid" in track:

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -526,15 +526,19 @@ class PlaylistMakerElement(Element):
 class RecordingsFromMusicServiceElement(Element):
     """ Create a troi.Playlist entity from track and artist names."""
 
-    def __init__(self, token=None, playlist_id=None):
+    def __init__(self, token=None, playlist_id=None, music_service=None, apple_music_token=None):
         """
             Args:
                 playlist_id: id of the Spotify playlist to be used for creating the playlist element
                 token: the Spotify token to fetch the playlist tracks
+                music_service: the name of the music service to be used for fetching the playlist data
+                apple_music_token (optional): the user token for Apple Music API 
         """
         super().__init__()
         self.token = token
         self.playlist_id = playlist_id
+        self.music_service = music_service
+        self.apple_music_token = apple_music_token
 
 
     @staticmethod
@@ -544,7 +548,7 @@ class RecordingsFromMusicServiceElement(Element):
     def read(self, inputs):
         recordings = []
 
-        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id)
+        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id, self.music_service, self.apple_music_token)
         if mbid_mapped_tracks:
             for mbid in mbid_mapped_tracks:
                 recordings.append(Recording(mbid=mbid))

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -546,9 +546,8 @@ class RecordingsFromMusicServiceElement(Element):
 
         mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id)
         if mbid_mapped_tracks:
-            for track in mbid_mapped_tracks:
-                if track is not None and "recording_mbid" in track:
-                    recordings.append(Recording(mbid=track["recording_mbid"]))
+            for mbid in mbid_mapped_tracks:
+                recordings.append(Recording(mbid=mbid))
 
         return recordings
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -548,13 +548,13 @@ class RecordingsFromMusicServiceElement(Element):
     def read(self, inputs):
         recordings = []
 
-        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id)
+        mbid_mapped_tracks, title, description = music_service_tracks_to_mbid(self.token, self.playlist_id)
         if mbid_mapped_tracks:
             for track in mbid_mapped_tracks:
                 if track is not None and "recording_mbid" in track:
                     recordings.append(Recording(mbid=track["recording_mbid"]))
     
-        return recordings
+        return recordings, title, description
 
     
 class PlaylistFromJSPFElement(Element):

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -9,7 +9,8 @@ import spotipy
 from troi import Recording, Playlist, PipelineError, Element, Artist, ArtistCredit, Release
 from troi.operations import is_homogeneous
 from troi.print_recording import PrintRecordingList
-from troi.tools.spotify_lookup import submit_to_spotify, music_service_tracks_to_mbid
+from troi.tools.common_lookup import music_service_tracks_to_mbid
+from troi.tools.spotify_lookup import submit_to_spotify
 
 logger = logging.getLogger(__name__)
 

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -548,13 +548,13 @@ class RecordingsFromMusicServiceElement(Element):
     def read(self, inputs):
         recordings = []
 
-        mbid_mapped_tracks, title, description = music_service_tracks_to_mbid(self.token, self.playlist_id)
+        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id)
         if mbid_mapped_tracks:
             for track in mbid_mapped_tracks:
                 if track is not None and "recording_mbid" in track:
                     recordings.append(Recording(mbid=track["recording_mbid"]))
     
-        return recordings, title, description
+        return recordings
 
     
 class PlaylistFromJSPFElement(Element):

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -526,7 +526,7 @@ class PlaylistMakerElement(Element):
 class RecordingsFromMusicServiceElement(Element):
     """ Create a troi.Playlist entity from track and artist names."""
 
-    def __init__(self, token=None, playlist_id=None, music_service=None, apple_music_token=None):
+    def __init__(self, token=None, playlist_id=None, music_service=None, apple_user_token=None):
         """
             Args:
                 playlist_id: id of the Spotify playlist to be used for creating the playlist element
@@ -538,7 +538,7 @@ class RecordingsFromMusicServiceElement(Element):
         self.token = token
         self.playlist_id = playlist_id
         self.music_service = music_service
-        self.apple_music_token = apple_music_token
+        self.apple_user_token = apple_user_token
 
 
     @staticmethod
@@ -548,7 +548,7 @@ class RecordingsFromMusicServiceElement(Element):
     def read(self, inputs):
         recordings = []
 
-        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id, self.music_service, self.apple_music_token)
+        mbid_mapped_tracks = music_service_tracks_to_mbid(self.token, self.playlist_id, self.music_service, self.apple_user_token)
         if mbid_mapped_tracks:
             for mbid in mbid_mapped_tracks:
                 recordings.append(Recording(mbid=mbid))

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -1,0 +1,31 @@
+import requests
+
+from troi.tools.spotify_lookup import APPLE_MUSIC_URL
+
+
+def convert_apple_tracks_to_json(apple_tracks):
+    tracks= []
+    for track in apple_tracks:
+        tracks.append({
+            "recording_name": track['attributes']['name'],
+            "artist_name": track['attributes']['artistName'],
+        })
+    return tracks
+
+
+def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
+    """ Get tracks from the Apple Music playlist.
+    """
+    headers = {
+        "Authorization": f"Bearer {developer_token}",
+        "Music-User-Token": user_token
+    }
+    response = requests.get(APPLE_MUSIC_URL+f"v1/me/library/playlists/{playlist_id}?include=tracks", headers=headers)
+    if response.status_code == 200:
+        response = response.json()
+        tracks = response["data"][0]["relationships"]["tracks"]["data"]
+        name = response["data"][0]["attributes"]["name"]
+        description = response["data"][0]["attributes"]["description"]["standard"]
+    else:
+        response.raise_for_status()
+    return tracks, name, description

--- a/troi/tools/common_lookup.py
+++ b/troi/tools/common_lookup.py
@@ -1,0 +1,47 @@
+import logging
+
+import requests
+from more_itertools import chunked
+
+from troi.tools.apple_lookup import get_tracks_from_apple_playlist, convert_apple_tracks_to_json
+from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist, convert_spotify_tracks_to_json
+
+MAX_LOOKUPS_PER_POST = 50
+MBID_LOOKUP_URL = "https://api.listenbrainz.org/1/metadata/lookup/"
+
+logger = logging.getLogger(__name__)
+
+
+def music_service_tracks_to_mbid(token, playlist_id, music_service, apple_user_token=None):
+    """ Convert Spotify playlist tracks to a list of MBID tracks.
+    """
+    if music_service == "spotify":
+        tracks_from_playlist, name, desc = get_tracks_from_spotify_playlist(token, playlist_id)
+        tracks = convert_spotify_tracks_to_json(tracks_from_playlist)
+    elif music_service == "apple_music":
+        tracks_from_playlist, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
+        tracks = convert_apple_tracks_to_json(tracks_from_playlist)
+    else:
+        raise ValueError("Unknown music service")
+
+    track_lists = list(chunked(tracks, MAX_LOOKUPS_PER_POST))
+    return mbid_mapping_spotify(track_lists)
+
+
+def mbid_mapping_spotify(track_lists):
+    """ Given a track_name and artist_name, try to find MBID for these tracks from mbid lookup.
+    """
+    track_mbids = []
+    for tracks in track_lists:
+        params = {
+            "recordings": tracks
+        }
+        response = requests.post(MBID_LOOKUP_URL, json=params)
+        if response.status_code == 200:
+            data = response.json()
+            for d in data:
+                if d is not None and "recording_mbid" in d:
+                    track_mbids.append(d["recording_mbid"])
+        else:
+            logger.error("Error occurred: %s", response.text)
+    return track_mbids

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -207,8 +207,6 @@ def music_service_tracks_to_mbid(token, playlist_id):
     tracks = _convert_tracks_to_json(tracks_from_playlist)
 
     track_lists = list(chunked(tracks, MAX_LOOKUPS_PER_POST))
-    print(track_lists)
-
     return mbid_mapping_spotify(track_lists)
 
 def mbid_mapping_spotify(track_lists):
@@ -219,11 +217,12 @@ def mbid_mapping_spotify(track_lists):
         params = {
             "recordings": tracks
         }
-        response = requests.post(MBID_LOOKUP_URL, params=params)
+        response = requests.post(MBID_LOOKUP_URL, json=params)
         if response.status_code == 200:
             data = response.json()
-            if data is not None and "recording_mbid" in data:
-                track_mbids.append(data["recording_mbid"])
+            for d in data:
+                if d is not None and "recording_mbid" in d:
+                    track_mbids.append(d["recording_mbid"])
         else:
             print("Error occurred:", response.status_code)
     return track_mbids

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -203,12 +203,12 @@ def _convert_tracks_to_json(tracks_from_playlist):
 def music_service_tracks_to_mbid(token, playlist_id):
     """ Convert Spotify playlist tracks to a list of MBID tracks.
     """
-    tracks_from_playlist, title, description = get_tracks_from_playlist(token, playlist_id)
+    tracks_from_playlist = get_tracks_from_playlist(token, playlist_id)
     tracks = _convert_tracks_to_json(tracks_from_playlist)
     
      # select track_name and artist_name for each track
     mbid_mapped_tracks = [mbid_mapping_spotify(track["track_name"], track["artist_name"]) for track in tracks]
-    return mbid_mapped_tracks, title, description
+    return mbid_mapped_tracks
     
     
 def mbid_mapping_spotify(track_name, artist_name):

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -174,7 +174,7 @@ def submit_to_spotify(spotify, playlist, spotify_user_id: str, is_public: bool =
 
 
 def get_tracks_from_playlist(spotify_token, playlist_id):
-    """ Get the tracks from Spotify playlist.
+    """ Get tracks from the Spotify playlist.
     """
     sp = spotipy.Spotify(auth=spotify_token, requests_timeout=10, retries=10)
     playlist_info = sp.playlist(playlist_id)
@@ -205,13 +205,15 @@ def music_service_tracks_to_mbid(token, playlist_id):
     """
     tracks_from_playlist, name, desc = get_tracks_from_playlist(token, playlist_id)
     tracks = _convert_tracks_to_json(tracks_from_playlist)
-    
+
      # select track_name and artist_name for each track
     mbid_mapped_tracks = [mbid_mapping_spotify(track["track_name"], track["artist_name"]) for track in tracks]
     return mbid_mapped_tracks
-    
-    
+
+
 def mbid_mapping_spotify(track_name, artist_name):
+    """ Given a track_name and artist_name, try to find MBID for these tracks from mbid lookup.
+    """
     params = {
         "artist_name": artist_name,
         "recording_name": track_name,

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -235,7 +235,7 @@ def music_service_tracks_to_mbid(token, playlist_id, music_service, apple_user_t
         tracks_from_playlist, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
     else:
         raise ValueError("Unknown music service")
-    tracks = _convert_tracks_to_json(tracks_from_playlist)
+    tracks = _convert_tracks_to_json(tracks_from_playlist, music_service)
 
     track_lists = list(chunked(tracks, MAX_LOOKUPS_PER_POST))
     return mbid_mapping_spotify(track_lists)

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -203,7 +203,7 @@ def _convert_tracks_to_json(tracks_from_playlist):
 def music_service_tracks_to_mbid(token, playlist_id):
     """ Convert Spotify playlist tracks to a list of MBID tracks.
     """
-    tracks_from_playlist = get_tracks_from_playlist(token, playlist_id)
+    tracks_from_playlist, name, desc = get_tracks_from_playlist(token, playlist_id)
     tracks = _convert_tracks_to_json(tracks_from_playlist)
     
      # select track_name and artist_name for each track

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -208,7 +208,7 @@ def music_service_tracks_to_mbid(token, playlist_id):
     
      # select track_name and artist_name for each track
     mbid_mapped_tracks = [mbid_mapping_spotify(track["track_name"], track["artist_name"]) for track in tracks]
-    return mbid_mapped_tracks
+    return mbid_mapped_tracks, title, description
     
     
 def mbid_mapping_spotify(track_name, artist_name):


### PR DESCRIPTION
- Added a new Patch ImportPlaylistPatch that creates a troi.playlist by importing Spotify Playlists
- Migrated some helper functions (get_tracks_from_spotify, mbid_mapping and etc.)
- Added a new Element to create a playlist based on track_names and artist_names (basically, works like playlist_from_mbid)


!!! It's not YET finished. I'm still testing the code with LB. I opened this pull request to track the changes and further commit them here. 