### PR TITLE
Fixed bug with description

### DIFF
--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -25,7 +25,7 @@ def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
         response = response.json()
         tracks = response["data"][0]["relationships"]["tracks"]["data"]
         name = response["data"][0]["attributes"]["name"]
-        description = response["data"][0]["attributes"]["description"]["standard"]
+        description = response["data"][0]["attributes"].get("description", {}).get("standard", "")
     else:
         response.raise_for_status()
     return tracks, name, description


### PR DESCRIPTION
In my recent commit, @/anshg1214 pointed out that Troi throws an error if a playlist lacks a description. I have resolved this issue by modifying the code to set the description to an empty string when none is provided

<img width="720" alt="Screenshot 2024-07-05 at 15 13 20" src="https://github.com/metabrainz/troi-recommendation-playground/assets/115300909/98b29203-208c-4eb0-bd1a-f4244b4218ec">
