### PR TITLE
Import Playlists from SoundCloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   'tqdm',
   'ujson>=5.4.0',
   'Unidecode>=1.3.6',
-  'ratelimit>=2.2.1',
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   'tqdm',
   'ujson>=5.4.0',
   'Unidecode>=1.3.6',
+  'ratelimit>=2.2.1',
 ]
 
 [project.scripts]

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -47,13 +47,13 @@ class ImportPlaylistPatch(Patch):
         playlist_id = inputs["playlist_id"]
         music_service = inputs["music_service"]
         apple_user_token = inputs["apple_user_token"]
-        
+
         if apple_user_token == "":
             apple_user_token = None
-        
+
         if music_service == "apple_music" and apple_user_token is None:
             raise RuntimeError("Authentication is required")
-        
+
         # this one only used to get track name and desc
         if music_service == "spotify":
             tracks, name, desc = get_tracks_from_spotify_playlist(ms_token, playlist_id)

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -6,6 +6,7 @@ from troi.playlist import RecordingsFromMusicServiceElement, PlaylistMakerElemen
 from troi.musicbrainz.recording_lookup import RecordingLookupElement
 from troi.tools.apple_lookup import get_tracks_from_apple_playlist
 from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist
+from troi.tools.soundcloud_lookup import get_tracks_from_soundcloud_playlist
 
 
 class ImportPlaylistPatch(Patch):
@@ -58,6 +59,8 @@ class ImportPlaylistPatch(Patch):
             tracks, name, desc = get_tracks_from_spotify_playlist(ms_token, playlist_id)
         elif music_service == "apple_music":
             tracks, name, desc = get_tracks_from_apple_playlist(ms_token, apple_user_token, playlist_id)
+        elif music_service == "soundcloud":
+            tracks, name, desc = get_tracks_from_soundcloud_playlist(ms_token, playlist_id)
 
         source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id, music_service=music_service, apple_user_token=apple_user_token)
         

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -1,29 +1,25 @@
 import requests
-from ratelimit import limits, sleep_and_retry
+from .utils import create_http_session
 
 APPLE_MUSIC_URL = f"https://api.music.apple.com/"
-CALLS=5
-RATE_LIMIT=1
 
-
-@sleep_and_retry
-@limits(calls=CALLS, period=RATE_LIMIT)
 def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """
+    http = create_http_session()
+
     headers = {
         "Authorization": f"Bearer {developer_token}",
         "Music-User-Token": user_token
     }
-    response = requests.get(APPLE_MUSIC_URL+f"v1/me/library/playlists/{playlist_id}?include=tracks", headers=headers)
-    if response.status_code == 200:
-        response = response.json()
-        tracks = response["data"][0]["relationships"]["tracks"]["data"]
-        name = response["data"][0]["attributes"]["name"]
-        description = response["data"][0]["attributes"].get("description", {}).get("standard", "")
-    else:
-        response.raise_for_status()
-  
+    response = http.get(APPLE_MUSIC_URL+f"v1/me/library/playlists/{playlist_id}?include=tracks", headers=headers)
+    response.raise_for_status()
+
+    response = response.json()
+    tracks = response["data"][0]["relationships"]["tracks"]["data"]
+    name = response["data"][0]["attributes"]["name"]
+    description = response["data"][0]["attributes"].get("description", {}).get("standard", "")
+
     mapped_tracks = [
         {
             "recording_name": track['attributes']['name'],

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -2,16 +2,6 @@ import requests
 
 APPLE_MUSIC_URL = f"https://api.music.apple.com/"
 
-def convert_apple_tracks_to_json(apple_tracks):
-    tracks= []
-    for track in apple_tracks:
-        tracks.append({
-            "recording_name": track['attributes']['name'],
-            "artist_name": track['attributes']['artistName'],
-        })
-    return tracks
-
-
 def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """
@@ -28,10 +18,12 @@ def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
     else:
         response.raise_for_status()
   
-    mapped_tracks= []
-    for track in tracks:
-        mapped_tracks.append({
+    mapped_tracks = [
+        {
             "recording_name": track['attributes']['name'],
-            "artist_name": track['attributes']['artistName'],
-        })
+            "artist_name": track['attributes']['artistName']
+        }
+        for track in tracks
+    ]
+
     return mapped_tracks, name, description

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -1,7 +1,13 @@
 import requests
+from ratelimit import limits, sleep_and_retry
 
 APPLE_MUSIC_URL = f"https://api.music.apple.com/"
+CALLS=5
+RATE_LIMIT=1
 
+
+@sleep_and_retry
+@limits(calls=CALLS, period=RATE_LIMIT)
 def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -1,4 +1,3 @@
-import requests
 from .utils import create_http_session
 
 APPLE_MUSIC_URL = f"https://api.music.apple.com/"

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -25,7 +25,7 @@ def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
         response = response.json()
         tracks = response["data"][0]["relationships"]["tracks"]["data"]
         name = response["data"][0]["attributes"]["name"]
-        description = response["data"][0]["attributes"]["description"]["standard"]
+        description = response["data"][0]["attributes"].get("description", {}).get("standard", "")
     else:
         response.raise_for_status()
     return tracks, name, description

--- a/troi/tools/common_lookup.py
+++ b/troi/tools/common_lookup.py
@@ -3,8 +3,9 @@ import logging
 import requests
 from more_itertools import chunked
 
-from troi.tools.apple_lookup import get_tracks_from_apple_playlist, convert_apple_tracks_to_json
-from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist, convert_spotify_tracks_to_json
+from troi.tools.apple_lookup import get_tracks_from_apple_playlist
+from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist
+from troi.tools.soundcloud_lookup import get_tracks_from_soundcloud_playlist
 
 MAX_LOOKUPS_PER_POST = 50
 MBID_LOOKUP_URL = "https://api.listenbrainz.org/1/metadata/lookup/"
@@ -17,18 +18,18 @@ def music_service_tracks_to_mbid(token, playlist_id, music_service, apple_user_t
     """
     if music_service == "spotify":
         tracks_from_playlist, name, desc = get_tracks_from_spotify_playlist(token, playlist_id)
-        tracks = convert_spotify_tracks_to_json(tracks_from_playlist)
     elif music_service == "apple_music":
-        tracks_from_playlist, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
-        tracks = convert_apple_tracks_to_json(tracks_from_playlist)
+        tracks, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
+    elif music_service == "soundcloud":
+        tracks, name, desc = get_tracks_from_soundcloud_playlist(token, playlist_id)
     else:
         raise ValueError("Unknown music service")
 
     track_lists = list(chunked(tracks, MAX_LOOKUPS_PER_POST))
-    return mbid_mapping_spotify(track_lists)
+    return mbid_mapping_tracks(track_lists)
 
 
-def mbid_mapping_spotify(track_lists):
+def mbid_mapping_tracks(track_lists):
     """ Given a track_name and artist_name, try to find MBID for these tracks from mbid lookup.
     """
     track_mbids = []

--- a/troi/tools/common_lookup.py
+++ b/troi/tools/common_lookup.py
@@ -17,7 +17,7 @@ def music_service_tracks_to_mbid(token, playlist_id, music_service, apple_user_t
     """ Convert Spotify playlist tracks to a list of MBID tracks.
     """
     if music_service == "spotify":
-        tracks_from_playlist, name, desc = get_tracks_from_spotify_playlist(token, playlist_id)
+        tracks, name, desc = get_tracks_from_spotify_playlist(token, playlist_id)
     elif music_service == "apple_music":
         tracks, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
     elif music_service == "soundcloud":

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -2,12 +2,13 @@ import requests
 from ratelimit import limits, sleep_and_retry
 
 SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
-CALLS=5
-RATE_LIMIT=1
 
+# Rate limit for API requests: maximum 5 requests per 1 second
+MAX_REQUESTS=5
+TIME_PERIOD=1
 
 @sleep_and_retry
-@limits(calls=CALLS, period=RATE_LIMIT)
+@limits(calls=MAX_REQUESTS, period=TIME_PERIOD)
 def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -30,9 +30,10 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
 
     mapped_tracks= []
     for track in tracks:
+        artist, song = track['title'].split(" - ")
         mapped_tracks.append({
-            "recording_name": track['title'],
-            "artist_name": track['user']['username'],
+            "recording_name": song,
+            "artist_name": artist,
         })
     
     print(mapped_tracks)

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -1,10 +1,10 @@
 import requests
 
-APPLE_MUSIC_URL = f"https://api.music.apple.com/"
+SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
 
-def convert_apple_tracks_to_json(apple_tracks):
+def convert_soundcloud_tracks_to_json(soundcloud_tracks):
     tracks= []
-    for track in apple_tracks:
+    for track in soundcloud_tracks:
         tracks.append({
             "recording_name": track['attributes']['name'],
             "artist_name": track['attributes']['artistName'],
@@ -12,22 +12,21 @@ def convert_apple_tracks_to_json(apple_tracks):
     return tracks
 
 
-def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
+def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """
     headers = {
         "Authorization": f"Bearer {developer_token}",
-        "Music-User-Token": user_token
     }
-    response = requests.get(APPLE_MUSIC_URL+f"v1/me/library/playlists/{playlist_id}?include=tracks", headers=headers)
+    response = requests.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
     if response.status_code == 200:
         response = response.json()
-        tracks = response["data"][0]["relationships"]["tracks"]["data"]
-        name = response["data"][0]["attributes"]["name"]
-        description = response["data"][0]["attributes"].get("description", {}).get("standard", "")
+        tracks = response["tracks"]
+        name = response["title"]
+        description = response["description"]
     else:
         response.raise_for_status()
-  
+
     mapped_tracks= []
     for track in tracks:
         mapped_tracks.append({
@@ -35,3 +34,6 @@ def get_tracks_from_apple_playlist(developer_token, user_token, playlist_id):
             "artist_name": track['attributes']['artistName'],
         })
     return mapped_tracks, name, description
+
+
+# get_tracks_from_soundcloud_playlist("2-294758-355389761-ipvsDC07nvDHUa", 384588551)

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -31,8 +31,8 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     mapped_tracks= []
     for track in tracks:
         mapped_tracks.append({
-            "recording_name": track['attributes']['name'],
-            "artist_name": track['attributes']['artistName'],
+            "recording_name": track['title'],
+            "artist_name": track['user']['username'],
         })
     
     print(mapped_tracks)

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -2,16 +2,6 @@ import requests
 
 SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
 
-def convert_soundcloud_tracks_to_json(soundcloud_tracks):
-    tracks= []
-    for track in soundcloud_tracks:
-        tracks.append({
-            "recording_name": track['attributes']['name'],
-            "artist_name": track['attributes']['artistName'],
-        })
-    return tracks
-
-
 def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """
@@ -20,7 +10,6 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     }
     response = requests.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
     if response.status_code == 200:
-        print("got in")
         response = response.json()
         tracks = response["tracks"]
         name = response["title"]
@@ -28,20 +17,12 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     else:
         response.raise_for_status()
 
-    mapped_tracks= []
-    for track in tracks:
-        if " - " in track['title']:
-            artist, song = track['title'].split(" - ")
-        else:
-            artist = track['user']['username']
-            song = track['title']
-        mapped_tracks.append({
-            "recording_name": song,
-            "artist_name": artist,
-        })
-    
-    print(mapped_tracks)
+    mapped_tracks = [
+        {
+            "recording_name": track['title'].split(" - ")[1] if " - " in track['title'] else track['title'],
+            "artist_name": track['title'].split(" - ")[0] if " - " in track['title'] else track['user']['username']
+        }
+        for track in tracks
+    ]
+
     return mapped_tracks, name, description
-
-
-# get_tracks_from_soundcloud_playlist("2-294758-355389761-ipvsDC07nvDHUa", 384588551)

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -1,28 +1,23 @@
 import requests
-from ratelimit import limits, sleep_and_retry
+from .utils import create_http_session
 
 SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
 
-# Rate limit for API requests: maximum 5 requests per 1 second
-MAX_REQUESTS=5
-TIME_PERIOD=1
-
-@sleep_and_retry
-@limits(calls=MAX_REQUESTS, period=TIME_PERIOD)
 def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
-    """ Get tracks from the Apple Music playlist.
+    """ Get tracks from the Soundcloud playlist.
     """
+    http = create_http_session()
+
     headers = {
         "Authorization": f"Bearer {developer_token}",
     }
-    response = requests.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
-    if response.status_code == 200:
-        response = response.json()
-        tracks = response["tracks"]
-        name = response["title"]
-        description = response["description"]
-    else:
-        response.raise_for_status()
+    response = http.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
+    response.raise_for_status()
+
+    response = response.json()
+    tracks = response["tracks"]
+    name = response["title"]
+    description = response["description"]
 
     mapped_tracks = [
         {

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -30,7 +30,11 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
 
     mapped_tracks= []
     for track in tracks:
-        artist, song = track['title'].split(" - ")
+        if " - " in track['title']:
+            artist, song = track['title'].split(" - ")
+        else:
+            artist = track['user']['username']
+            song = track['title']
         mapped_tracks.append({
             "recording_name": song,
             "artist_name": artist,

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -1,7 +1,13 @@
 import requests
+from ratelimit import limits, sleep_and_retry
 
 SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
+CALLS=5
+RATE_LIMIT=1
 
+
+@sleep_and_retry
+@limits(calls=CALLS, period=RATE_LIMIT)
 def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """ Get tracks from the Apple Music playlist.
     """

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -20,6 +20,7 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     }
     response = requests.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
     if response.status_code == 200:
+        print("got in")
         response = response.json()
         tracks = response["tracks"]
         name = response["title"]
@@ -33,6 +34,8 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
             "recording_name": track['attributes']['name'],
             "artist_name": track['attributes']['artistName'],
         })
+    
+    print(mapped_tracks)
     return mapped_tracks, name, description
 
 

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -1,4 +1,3 @@
-import requests
 from .utils import create_http_session
 
 SOUNDCLOUD_URL = f"https://api.soundcloud.com/"
@@ -9,9 +8,9 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     http = create_http_session()
 
     headers = {
-        "Authorization": f"Bearer {developer_token}",
+        "Authorization": f"OAuth {developer_token}",
     }
-    response = http.get(SOUNDCLOUD_URL+f"/playlists/{playlist_id}", headers=headers)
+    response = http.get(f"{SOUNDCLOUD_URL}/playlists/{playlist_id}", headers=headers)
     response.raise_for_status()
 
     response = response.json()

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -182,6 +182,7 @@ def get_tracks_from_spotify_playlist(spotify_token, playlist_id):
     name = playlist_info["name"]
     description = playlist_info["description"]
     
+    tracks = convert_spotify_tracks_to_json(tracks)
     return tracks, name, description
 
 

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -1,0 +1,26 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def create_http_session():
+    """ Create an HTTP session with retry strategy for handling rate limits and server errors.
+    """
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=[429, 500, 502, 503, 504], 
+        allowed_methods=["HEAD", "GET", "OPTIONS"], 
+        backoff_factor=1
+    )
+
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    http = requests.Session()
+    http.mount("https://", adapter)
+    http.mount("http://", adapter)
+
+    def _assert_status_hook(response, *args, **kwargs):
+        response.raise_for_status()
+
+    http.hooks["response"] = [_assert_status_hook]
+
+    return http

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -17,10 +17,4 @@ def create_http_session():
     http = requests.Session()
     http.mount("https://", adapter)
     http.mount("http://", adapter)
-
-    def _assert_status_hook(response, *args, **kwargs):
-        response.raise_for_status()
-
-    http.hooks["response"] = [_assert_status_hook]
-
     return http


### PR DESCRIPTION
- Added SoundCloud playlist import support to `ImportPlaylistPatch`.
- Optimized code for Apple and Spotify playlist imports by removing unnecessary functions like `convert_track_to_json`.

NOTE: SoundCloud tracks store categories differently from Apple/Spotify as they do not store artist names separately. For starters, I implemented a small code snippet that splits the title into the artist name and track name. This code handles most SoundCloud tracks but does not cover all cases. We plan to implement a new function to identify SoundCloud title patterns and optimize the process for a broader set of tracks.