### PR TITLE
[bugfix]: Do not require Subsonic disc/track number, fix lb-radio artist locally

### DIFF
--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -136,8 +136,9 @@ class SubsonicDatabase(Database):
                     "release_mbid": album_mbid,
                     "recording_mbid": song["musicBrainzId"],
                     "duration": song["duration"] * 1000,
-                    "track_num": song["track"],
-                    "disc_num": song["discNumber"],
+                    # Neither track number nor disc number are guaranteed for subsonic
+                    "track_num": song.get("track", 1),
+                    "disc_num": song.get("discNumber", 1),
                     "subsonic_id": song["id"],
                     "mtime": datetime.datetime.now()
                     })

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -52,7 +52,8 @@ class LBRadioArtistRecordingElement(troi.Element):
 
             try:
                 similar_artist_names.append(artist_recordings[mbid][0].artist_credit.name)
-            except IndexError:
+                # The item may not exist, or the artist credit may be None
+            except (AttributeError, IndexError):
                 pass
 
         # craft user feedback messages


### PR DESCRIPTION
This change has a few fixes:
- For subsonic import, allow track and disc number to be None (and default to 1). Subsonic servers are **not** guaranteed to return values here. Tested on my Navidrome instance
- Multiple fixes for get_similar_artists: proper post parameter, parse response, query using list of ids (not dicts), and return an empty array for msgs
- For `artist.py`, in some cases the `artist_credit` is `None`, also allow for this (via `AttributeError`)

These changes were tested locally by importing via subsonic, importing metadata, and then doing `lbz-radio` with an artist, and then with a tag.