### PR TITLE
SoundCloud import tracks fix

### DIFF
--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -54,13 +54,17 @@ class ImportPlaylistPatch(Patch):
         if music_service == "apple_music" and apple_user_token is None:
             raise RuntimeError("Authentication is required")
 
-        # this one only used to get track name and desc
-        if music_service == "spotify":
-            tracks, name, desc = get_tracks_from_spotify_playlist(ms_token, playlist_id)
-        elif music_service == "apple_music":
-            tracks, name, desc = get_tracks_from_apple_playlist(ms_token, apple_user_token, playlist_id)
-        elif music_service == "soundcloud":
-            tracks, name, desc = get_tracks_from_soundcloud_playlist(ms_token, playlist_id)
+        playlist_fetchers = {
+            "spotify": get_tracks_from_spotify_playlist,
+            "apple_music": get_tracks_from_apple_playlist,
+            "soundcloud": get_tracks_from_soundcloud_playlist
+        }
+
+        get_tracks = playlist_fetchers.get(music_service)
+        if not get_tracks:
+            raise ValueError(f"Unsupported music service: {music_service}")
+
+        _, name, desc = get_tracks(ms_token, playlist_id, apple_user_token) if music_service == "apple_music" else get_tracks(ms_token, playlist_id)
 
         source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id, music_service=music_service, apple_user_token=apple_user_token)
         

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -6,7 +6,7 @@ from troi.playlist import RecordingsFromMusicServiceElement, PlaylistMakerElemen
 from troi.musicbrainz.recording_lookup import RecordingLookupElement
 from troi.tools.apple_lookup import get_tracks_from_apple_playlist
 from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist
-from troi.tools.soundcloud_lookup import get_tracks_from_soundcloud_playlist
+from troi.tools.soundcloud_lookup import get_soundcloud_playlist
 
 
 class ImportPlaylistPatch(Patch):
@@ -57,7 +57,7 @@ class ImportPlaylistPatch(Patch):
         playlist_fetchers = {
             "spotify": get_tracks_from_spotify_playlist,
             "apple_music": get_tracks_from_apple_playlist,
-            "soundcloud": get_tracks_from_soundcloud_playlist
+            "soundcloud": get_soundcloud_playlist
         }
 
         get_tracks = playlist_fetchers.get(music_service)

--- a/troi/patches/playlist_from_ms.py
+++ b/troi/patches/playlist_from_ms.py
@@ -64,7 +64,7 @@ class ImportPlaylistPatch(Patch):
         if not get_tracks:
             raise ValueError(f"Unsupported music service: {music_service}")
 
-        _, name, desc = get_tracks(ms_token, playlist_id, apple_user_token) if music_service == "apple_music" else get_tracks(ms_token, playlist_id)
+        _, name, desc = get_tracks(ms_token, apple_user_token, playlist_id) if music_service == "apple_music" else get_tracks(ms_token, playlist_id)
 
         source = RecordingsFromMusicServiceElement(token=ms_token, playlist_id=playlist_id, music_service=music_service, apple_user_token=apple_user_token)
         

--- a/troi/tools/common_lookup.py
+++ b/troi/tools/common_lookup.py
@@ -21,7 +21,7 @@ def music_service_tracks_to_mbid(token, playlist_id, music_service, apple_user_t
     elif music_service == "apple_music":
         tracks, name, desc = get_tracks_from_apple_playlist(token, apple_user_token, playlist_id)
     elif music_service == "soundcloud":
-        tracks, name, desc = get_tracks_from_soundcloud_playlist(token, playlist_id)
+        tracks = get_tracks_from_soundcloud_playlist(token, playlist_id)
     else:
         raise ValueError("Unknown music service")
 

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -151,7 +151,7 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
 def get_soundcloud_playlist(developer_token, playlist_id):
     soundcloud = SoundcloudAPI(developer_token)
     data = soundcloud.get_playlist(playlist_id)
-
+    logger.info(data)
     name = data["title"]
     description = data.get("description", "")
     

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -147,7 +147,6 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
 def get_soundcloud_playlist(developer_token, playlist_id):
     soundcloud = SoundcloudAPI(developer_token)
     data = soundcloud.get_playlist(playlist_id)
-    logger.info(data)
     name = data["title"]
     description = data["description"]
 

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -148,6 +148,16 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     return mapped_tracks, name, description
 
 
+def get_soundcloud_playlist(developer_token, playlist_id):
+    soundcloud = SoundcloudAPI(developer_token)
+    data = soundcloud.get_playlist(playlist_id)
+
+    name = data["title"]
+    description = data.get("description", "")
+    
+    return "", name, description
+
+
 def submit_to_soundcloud(soundcloud: SoundcloudAPI, playlist, is_public: bool = True,
                     existing_url: str = None):
     """ Submit or update an existing soundcloud playlist.

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -149,8 +149,8 @@ def get_soundcloud_playlist(developer_token, playlist_id):
     data = soundcloud.get_playlist(playlist_id)
     logger.info(data)
     name = data["title"]
-    description = data.get("description", "")
-    
+    description = data["description"]
+
     return "", name, description
 
 

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -132,7 +132,7 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """
     soundcloud = SoundcloudAPI(developer_token)
     data = soundcloud.get_playlist_tracks(playlist_id, linked_partitioning=True, limit=100, access=['playable, preview ,blocked'])
-
+    logger.info(data)
     tracks = data["tracks"]
     name = data["title"]
     description = data["description"]

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -151,6 +151,9 @@ def get_soundcloud_playlist(developer_token, playlist_id):
     name = data["title"]
     description = data["description"]
 
+    if description is None:
+        description = ""
+
     return "", name, description
 
 

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -131,11 +131,7 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
     """ Get tracks from the Soundcloud playlist.
     """
     soundcloud = SoundcloudAPI(developer_token)
-    data = soundcloud.get_playlist_tracks(playlist_id, linked_partitioning=True, limit=100, access=['playable, preview ,blocked'])
-    logger.info(data)
-    tracks = data["tracks"]
-    name = data["title"]
-    description = data["description"]
+    tracks = soundcloud.get_playlist_tracks(playlist_id, linked_partitioning=True, limit=100, access=['playable, preview ,blocked'])
 
     mapped_tracks = [
         {
@@ -145,7 +141,7 @@ def get_tracks_from_soundcloud_playlist(developer_token, playlist_id):
         for track in tracks
     ]
 
-    return mapped_tracks, name, description
+    return mapped_tracks
 
 
 def get_soundcloud_playlist(developer_token, playlist_id):

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -153,7 +153,7 @@ def get_soundcloud_playlist(developer_token, playlist_id):
     if description is None:
         description = ""
 
-    return "", name, description
+    return [], name, description
 
 
 def submit_to_soundcloud(soundcloud: SoundcloudAPI, playlist, is_public: bool = True,

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -137,6 +137,7 @@ class SoundcloudAPI:
 
         while url:
             response = self.session.get(url, headers=self.headers, params=kwargs)
+            logger.info("response: %s", response.json())
             data = response.json()
             tracks.extend(data.get("collection", []))
             url = data.get("next_href")

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -131,6 +131,14 @@ class SoundcloudAPI:
 
         return track_details
 
+
+    def get_playlist(self, playlist_id):
+        url = f"{SOUNDCLOUD_URL}/playlists/{playlist_id}"
+
+        response = self.session.get(url, headers=self.headers)
+        return response.json()
+
+
     def get_playlist_tracks(self, playlist_id, **kwargs):
         tracks = []
         url = f"{SOUNDCLOUD_URL}/playlists/{playlist_id}/tracks"

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -133,14 +133,12 @@ class SoundcloudAPI:
 
     def get_playlist_tracks(self, playlist_id, **kwargs):
         tracks = []
-        logger.info(self.headers)
         url = f"{SOUNDCLOUD_URL}/playlists/{playlist_id}/tracks"
 
         while url:
             response = self.session.get(url, headers=self.headers, params=kwargs)
-            logger.info("response: %s", response.json())
             data = response.json()
-            tracks.extend(data.get("collection", []))
+            tracks.extend(data.get('collection', []))
             url = data.get("next_href")
 
         return tracks

--- a/troi/tools/utils.py
+++ b/troi/tools/utils.py
@@ -133,6 +133,7 @@ class SoundcloudAPI:
 
     def get_playlist_tracks(self, playlist_id, **kwargs):
         tracks = []
+        logger.info(self.headers)
         url = f"{SOUNDCLOUD_URL}/playlists/{playlist_id}/tracks"
 
         while url:


### PR DESCRIPTION
Thanks to @anshg1214 for highlighting this in the [PR](https://github.com/metabrainz/listenbrainz-server/pull/2965#pullrequestreview-2271886561). We noticed that importing playlists from SoundCloud wasn't functioning correctly

The issue stemmed from the endpoint output. After updating the API callback to support pagination, it returned tracks but omitted playlist details.

I discovered that the playlist endpoint doesn’t support pagination, so I implemented a separate endpoint specifically for fetching the playlist name and description.

This approach seems effective, and I’m considering applying a similar solution for other services