### PR TITLE
LB-1628: LB radio 429 fix

### DIFF
--- a/troi/content_resolver/artist_search.py
+++ b/troi/content_resolver/artist_search.py
@@ -2,6 +2,7 @@ import os
 from collections import defaultdict
 import datetime
 import sys
+from time import sleep
 
 import peewee
 import requests

--- a/troi/content_resolver/artist_search.py
+++ b/troi/content_resolver/artist_search.py
@@ -37,15 +37,21 @@ class LocalRecordingSearchByArtistService(RecordingSearchByArtistService):
     def get_similar_artists(self, artist_mbid):
         """ Fetch similar artists, given an artist_mbid. Returns a sored plist of artists. """
 
-        r = requests.post("https://labs.api.listenbrainz.org/similar-artists/json",
-                          json=[{
-                              'artist_mbids':
-                              [artist_mbid],
-                              'algorithm':
-                              "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30"
-                          }])
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch similar artists: {r.status_code} ({r.text})")
+        while True:
+            r = requests.post("https://labs.api.listenbrainz.org/similar-artists/json",
+                              json=[{
+                                  'artist_mbids':
+                                  [artist_mbid],
+                                  'algorithm':
+                                  "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30"
+                              }])
+            if r.status_code == 429:
+                sleep(2)
+                continue
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch similar artists: {r.status_code} ({r.text})")
+
+            break
 
         artists = r.json()
 

--- a/troi/content_resolver/unresolved_recording.py
+++ b/troi/content_resolver/unresolved_recording.py
@@ -100,13 +100,13 @@ class UnresolvedRecordingTracker:
             params = {"recording_mbids": args, "inc": "artist release"}
             while True:
                 r = requests.get("https://api.listenbrainz.org/1/metadata/recording", params=params)
-                if r.status_code != 200:
-                    logger.info("Failed to fetch metadata for recordings: ", r.text)
-                    return []
-
                 if r.status_code == 429:
                     sleep(1)
                     continue
+
+                if r.status_code != 200:
+                    logger.info("Failed to fetch metadata for recordings: ", r.text)
+                    return []
 
                 break
             recording_data.update(dict(r.json()))

--- a/troi/musicbrainz/mbid_mapping.py
+++ b/troi/musicbrainz/mbid_mapping.py
@@ -36,9 +36,17 @@ class MBIDMappingLookupElement(Element):
         if not params:
             return []
 
-        r = requests.post(self.SERVER_URL, json=params)
-        if r.status_code != 200:
-            raise PipelineError("Cannot fetch MBID mapping rows from ListenBrainz: HTTP code %d (%s)" % (r.status_code, r.text))
+        while True:
+            r = requests.post(self.SERVER_URL, json=params)
+            if r.status_code == 429:
+                sleep(2)
+                continue
+
+            if r.status_code != 200:
+                raise PipelineError("Cannot fetch MBID mapping rows from ListenBrainz: HTTP code %d (%s)" % (r.status_code, r.text))
+
+            break
+
 
         entities = []
         for row in r.json():

--- a/troi/musicbrainz/mbid_mapping.py
+++ b/troi/musicbrainz/mbid_mapping.py
@@ -1,5 +1,6 @@
 import requests
 import ujson
+from time import sleep
 
 from troi import Element, Artist, ArtistCredit, Recording, Release, PipelineError
 

--- a/troi/musicbrainz/recording_lookup.py
+++ b/troi/musicbrainz/recording_lookup.py
@@ -15,6 +15,7 @@ class RecordingLookupElement(Element):
     '''
 
     SERVER_URL = "https://api.listenbrainz.org/1/metadata/recording"
+    MAX_RECORDINGS = 1000
 
     def __init__(self, skip_not_found=True, lookup_tags=False, tag_threshold=None):
         Element.__init__(self)
@@ -42,6 +43,9 @@ class RecordingLookupElement(Element):
         recording_mbids = []
         for r in recordings:
             recording_mbids.append(r.mbid)
+
+        if len(recording_mbids) > self.MAX_RECORDINGS:
+            raise PipelineError("Cannot fetch more than %d recordings from ListenBrainz." % self.MAX_RECORDINGS)
 
         inc = "artist release"
         if self.lookup_tags:

--- a/troi/musicbrainz/related_artist_credits.py
+++ b/troi/musicbrainz/related_artist_credits.py
@@ -1,5 +1,6 @@
 import copy
 from collections import defaultdict
+from time import sleep
 
 import requests
 

--- a/troi/musicbrainz/related_artist_credits.py
+++ b/troi/musicbrainz/related_artist_credits.py
@@ -31,9 +31,18 @@ class RelatedArtistCreditsElement(Element):
         ac_ids = ",".join([ str(a.artist_credit_id) for a in artists ])
         params = {"[artist_credit_id]": ac_ids,
                   "threshold": self.threshold}
-        r = requests.get(self.SERVER_URL, params=params)
-        if r.status_code != 200:
-            raise PipelineError("Cannot fetch related artist credits from ListenBrainz: HTTP code %d" % r.status_code)
+
+        while True:
+            r = requests.get(self.SERVER_URL, params=params)
+            if r.status_code == 429:
+                sleep(2)
+                continue
+
+            if r.status_code != 200:
+                raise PipelineError("Cannot fetch related artist credits from ListenBrainz: HTTP code %d" % r.status_code)
+
+            break
+
 
         try:
             relations = r.text

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -119,7 +119,7 @@ class LBRadioPatch(troi.patch.Patch):
             if r.status_code == 404:
                 raise RuntimeError(f"Could not resolve artist mbid {artist_mbid}. Error {r.status_code} {r.text}")
 
-            if r.status_code == 429:
+            if r.status_code in (429, 503):
                 sleep(2)
                 continue
 

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -1,3 +1,4 @@
+from time import sleep
 
 import troi
 from troi import Recording, Artist

--- a/troi/patches/lb_radio_classes/artist.py
+++ b/troi/patches/lb_radio_classes/artist.py
@@ -1,4 +1,3 @@
-import requests
 
 import troi
 from troi import Recording, Artist
@@ -16,6 +15,7 @@ class LBRadioArtistRecordingElement(troi.Element):
 
     MAX_TOP_RECORDINGS_PER_ARTIST = 35  # should lower this when other sources of data get added
     MAX_NUM_SIMILAR_ARTISTS = 8
+    MAX_NUM_RECORDINGS = 1000
 
     def __init__(self, artist_mbid, artist_name, mode="easy", include_similar_artists=True):
         troi.Element.__init__(self)
@@ -80,4 +80,4 @@ class LBRadioArtistRecordingElement(troi.Element):
             self.local_storage["user_feedback"].append(msg)
         self.data_cache["element-descriptions"].append("artist %s" % self.artist_name)
 
-        return interleave([artist_recordings[mbid] for mbid in artist_recordings])
+        return interleave([artist_recordings[mbid] for mbid in artist_recordings])[:self.MAX_NUM_RECORDINGS]

--- a/troi/patches/lb_radio_classes/collection.py
+++ b/troi/patches/lb_radio_classes/collection.py
@@ -1,8 +1,9 @@
-import troi
 from random import shuffle
+from time import sleep
 
 import requests
 
+import troi
 from troi import Recording
 from troi import TARGET_NUMBER_OF_RECORDINGS
 

--- a/troi/patches/lb_radio_classes/collection.py
+++ b/troi/patches/lb_radio_classes/collection.py
@@ -30,11 +30,20 @@ class LBRadioCollectionRecordingElement(troi.Element):
 
         # Fetch collection recordings
         params = {"collection": self.mbid, "fmt": "json"}
-        r = requests.get("https://musicbrainz.org/ws/2/recording", params=params)
-        if r.status_code == 404:
-            raise RuntimeError(f"Cannot find collection {self.mbid}.")
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch collection {self.mbid}. {r.text}")
+
+        while True:
+            r = requests.get("https://musicbrainz.org/ws/2/recording", params=params)
+            if r.status_code == 404:
+                raise RuntimeError(f"Cannot find collection {self.mbid}.")
+
+            if r.status_code == 429:
+                sleep(2)
+                continue
+
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch collection {self.mbid}. {r.text}")
+
+            break
 
         # Give feedback about what we collected
         self.local_storage["data_cache"]["element-descriptions"].append(f"collection {self.mbid}")

--- a/troi/patches/lb_radio_classes/country.py
+++ b/troi/patches/lb_radio_classes/country.py
@@ -37,7 +37,7 @@ class LBRadioCountryRecordingElement(Element):
 
         while True:
             r = requests.get("https://musicbrainz.org/ws/2/area?query=%s&fmt=json" % area_name)
-            if r.status_code == 503:
+            if r.status_code in (503, 429):
                 sleep(1)
                 continue
 
@@ -58,7 +58,7 @@ class LBRadioCountryRecordingElement(Element):
 
         while True:
             r = requests.get("https://musicbrainz.org/ws/2/area/%s?fmt=json" % area_mbid)
-            if r.status_code == 503:
+            if r.status_code in (503, 429):
                 sleep(1)
                 continue
 

--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -29,11 +29,17 @@ class LBRadioPlaylistRecordingElement(troi.Element):
     def read(self, entities):
 
         # Fetch the playlist
-        r = requests.get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
-        if r.status_code == 404:
-            raise RuntimeError(f"Cannot find playlist {self.mbid}.")
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch playlist {self.mbid}. {r.text}")
+        while True:
+            r = requests.get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
+            if r.status_code == 404:
+                raise RuntimeError(f"Cannot find playlist {self.mbid}.")
+            if r.status_code == 429:
+                sleep(2)
+                continue
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch playlist {self.mbid}. {r.text}")
+
+            break
 
         # Give feedback about the playlist
         self.local_storage["data_cache"]["element-descriptions"].append(f"playlist {self.mbid}")

--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -1,4 +1,5 @@
 import troi
+from time import sleep
 from random import shuffle
 
 import requests

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 import json
+from time import sleep
 
 
 import requests

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -273,16 +273,24 @@ class PlaylistElement(Element):
             logger.info("submit %d tracks" % len(playlist.recordings))
             if playlist.patch_slug is not None:
                 playlist.add_metadata({"algorithm_metadata": {"source_patch": playlist.patch_slug}})
-            r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,
-                              json=_serialize_to_jspf(playlist, created_for),
-                              headers={"Authorization": "Token " + str(token)})
-            if r.status_code != 200:
-                try:
-                    err = r.json()["error"]
-                except json.decoder.JSONDecodeError:
-                    err = r.text
 
-                raise PipelineError("Cannot post playlist to ListenBrainz: HTTP code %d: %s" % (r.status_code, err))
+            while True:
+                r = requests.post(LISTENBRAINZ_PLAYLIST_CREATE_URL,
+                                  json=_serialize_to_jspf(playlist, created_for),
+                                  headers={"Authorization": "Token " + str(token)})
+                if r.status_code == 429:
+                    sleep(2)
+                    continue
+
+                if r.status_code != 200:
+                    try:
+                        err = r.json()["error"]
+                    except json.decoder.JSONDecodeError:
+                        err = r.text
+
+                    raise PipelineError("Cannot post playlist to ListenBrainz: HTTP code %d: %s" % (r.status_code, err))
+
+                break
 
             try:
                 result = json.loads(r.text)

--- a/troi/recording_search_service.py
+++ b/troi/recording_search_service.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from time import sleep
 
 import requests
 

--- a/troi/recording_search_service.py
+++ b/troi/recording_search_service.py
@@ -26,9 +26,17 @@ class RecordingSearchByTagService(Service):
             "pop_end": pop_end,
             "tag": tags
         }
-        r = requests.get("https://api.listenbrainz.org/1/lb-radio/tags", params=data)
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch recordings for tags. {r.text}")
+        while True:
+            r = requests.get("https://api.listenbrainz.org/1/lb-radio/tags", params=data)
+            if r.status_code == 429:
+                sleep(2)
+                continue
+
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch recordings for tags. {r.text}")
+
+            break
+
 
         return plist([ Recording(mbid=rec["recording_mbid"], musicbrainz={"popularity": rec["percent"]}) for rec in r.json() ])
 
@@ -59,9 +67,17 @@ class RecordingSearchByArtistService(Service):
         }
         url = f"https://api.listenbrainz.org/1/lb-radio/artist/{artist_mbid}"
 
-        r = requests.get(url, params=params)
-        if r.status_code != 200:
-            raise RuntimeError(f"Cannot fetch lb_radio artists: {r.status_code} ({r.text})")
+        while True:
+            r = requests.get(url, params=params)
+            if r.status_code == 429:
+                sleep(2)
+                continue
+
+            if r.status_code != 200:
+                raise RuntimeError(f"Cannot fetch lb_radio artists: {r.status_code} ({r.text})")
+
+            break
+
 
         try:
             artists = r.json()

--- a/troi/tools/area_lookup.py
+++ b/troi/tools/area_lookup.py
@@ -1,4 +1,5 @@
 import requests
+from time import sleep
 import ujson
 
 from troi import PipelineError, DEVELOPMENT_SERVER_URL

--- a/troi/tools/area_lookup.py
+++ b/troi/tools/area_lookup.py
@@ -10,9 +10,15 @@ def area_lookup(area_name):
     '''
 
     data = [ { '[area]': area_name } ]
-    r = requests.post(AREA_LOOKUP_SERVER_URL, json=data)
-    if r.status_code != 200:
-        raise PipelineError("Cannot lookup area name. " + str(r.text))
+    while True:
+        r = requests.post(AREA_LOOKUP_SERVER_URL, json=data)
+        if r.status_code == 429:
+            sleep(2)
+            continue
+        if r.status_code != 200:
+            raise PipelineError("Cannot lookup area name. " + str(r.text))
+
+        break
 
     try:
         rows = ujson.loads(r.text)


### PR DESCRIPTION
LB-1628 points out that LB Radio is crap at dealing with rate limiting, so this PR ensures that request calls handle 439/503 correctly. 

Also, for some queries more than 1,000 items were generated, which caused problems. Truncating to first 1,000 tracks is a sufficient fix for this.