### PR TITLE
Update user-guide.rst: resolve subsonic -> troi db subsonic

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -115,7 +115,7 @@ To scan a subsonic collection, you'll need to setup a config.py file. See above.
 
 .. code-block:: bash
 
-   resolve subsonic
+   troi db subsonic
 
 This discovers the files present in the subsonic API hosted collection and adds a reference
 to the local DB.


### PR DESCRIPTION
`resolve subsonic` or `troi resolve subsonic` did not work for me, but looks like this is now `troi db subsonic`.

This still times out against my funkwhale server