### PR TITLE
Fix subsonic upload_playlist not properly removing existing entries

### DIFF
--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -255,11 +255,12 @@ class SubsonicDatabase(Database):
         if playlist_id:
             try:
                 remote_playlist = conn.getPlaylist(pid=playlist_id)
+                removed_song_idx = list(range(0, remote_playlist["playlist"]["songCount"]))
                 conn.updatePlaylist(
                     lid=playlist_id,
                     name=playlist.playlists[0].name,
                     songIdsToAdd=song_ids,
-                    songIndexesToRemove=list(range(0, len(remote_playlist["playlist"]) - 1)),
+                    songIndexesToRemove=removed_song_idx,
                 )
             except DataNotFoundError:
                 conn.createPlaylist(name=playlist.playlists[0].name, songIds=song_ids)


### PR DESCRIPTION
The subsonic `upload_playlist` changes in #152 did not generate the removed indexes list correctly. Instead of the entries in the playlist it just counted the elements in the "playlist" structure, which is an object with various data about the playlist.

This change uses the `songCount` field to determine how many entries are in the playlist.

I tested this with subsonic, and now my weekly playlist is no longer growing every time it gets updated.