### PR TITLE
Improve http fetching

### DIFF
--- a/tests/musicbrainz/test_mbid_mapping.py
+++ b/tests/musicbrainz/test_mbid_mapping.py
@@ -39,7 +39,7 @@ def mocked_requests_post(*args, **kwargs):
 
 class TestMBIDMapping(unittest.TestCase):
 
-    @unittest.mock.patch('requests.post', side_effect=mocked_requests_post)
+    @unittest.mock.patch('troi.http_request.http_post', side_effect=mocked_requests_post)
     def test_read(self, req):
 
         e = troi.musicbrainz.mbid_mapping.MBIDMappingLookupElement()
@@ -57,7 +57,7 @@ class TestMBIDMapping(unittest.TestCase):
         assert entities[0].mbid == "97e69767-5d34-4c97-b36a-f3b2b1ef9dae"
         assert entities[0].name == "Trigger Hippie"
 
-    @unittest.mock.patch('requests.post')
+    @unittest.mock.patch('troi.http_request.http_post')
     def test_read_remove_unmatched(self, req):
 
         mock = unittest.mock.MagicMock()

--- a/tests/musicbrainz/test_recording_lookup.py
+++ b/tests/musicbrainz/test_recording_lookup.py
@@ -303,7 +303,7 @@ return_json = {
 
 class TestRecordingLookup(unittest.TestCase):
 
-    @unittest.mock.patch('requests.post')
+    @unittest.mock.patch('troi.http_request.http_post')
     def test_read(self, req):
 
         mock = unittest.mock.MagicMock()

--- a/tests/musicbrainz/test_related_artist_credits.py
+++ b/tests/musicbrainz/test_related_artist_credits.py
@@ -23,7 +23,7 @@ return_json = [
 
 class TestArtistCreditNameLookup(unittest.TestCase):
 
-    @unittest.mock.patch('requests.get')
+    @unittest.mock.patch('troi.http_request.http_get')
     def test_read(self, req):
 
         mock = unittest.mock.MagicMock()

--- a/tests/tools/test_area_lookup.py
+++ b/tests/tools/test_area_lookup.py
@@ -20,7 +20,7 @@ return_json = [
 
 class TestAreaLookup(unittest.TestCase):
 
-    @unittest.mock.patch('requests.post')
+    @unittest.mock.patch('troi.http_request.http_post')
     def test_area_lookup(self, req):
 
         mock = unittest.mock.MagicMock()

--- a/troi/content_resolver/metadata_lookup.py
+++ b/troi/content_resolver/metadata_lookup.py
@@ -3,12 +3,12 @@ from collections import defaultdict, namedtuple
 import datetime
 from time import sleep
 
-import requests
 from tqdm import tqdm
 
 from troi.content_resolver.model.database import db
 from troi.content_resolver.model.recording import Recording, RecordingMetadata
 from troi.content_resolver.model.tag import RecordingTag
+from troi.http_request import http_post
 
 logger = logging.getLogger("troi_metadata_lookup")
 
@@ -68,17 +68,10 @@ class MetadataLookup:
             mbid_to_recording[rec.mbid] = rec
             args.append({"recording_mbid": rec.mbid})
 
-        while True:
-            r = requests.post("https://labs.api.listenbrainz.org/bulk-tag-lookup/json", json=args)
-            if r.status_code == 429:
-                sleep(2)
-                continue
-
-            if r.status_code != 200:
-                logger.info("Fail: %d %s" % (r.status_code, r.text))
-                return False
-
-            break
+        r = http_post("https://labs.api.listenbrainz.org/bulk-tag-lookup/json", json=args)
+        if r.status_code != 200:
+            logger.info("Fail: %d %s" % (r.status_code, r.text))
+            return False
 
         recording_pop = {}
         recording_tags = defaultdict(lambda: defaultdict(list))

--- a/troi/content_resolver/tag_search.py
+++ b/troi/content_resolver/tag_search.py
@@ -4,7 +4,6 @@ import datetime
 import sys
 
 import peewee
-import requests
 
 from troi.content_resolver.model.database import db
 from troi.content_resolver.model.recording import Recording, RecordingMetadata

--- a/troi/http_request.py
+++ b/troi/http_request.py
@@ -1,0 +1,36 @@
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+def requests_retry_session(
+    retries=3,
+    backoff_factor=0.3,
+    status_forcelist=(500, 502, 504, 503, 419),
+    session=None,
+):
+    session = session or requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+
+def http_get(url, headers=None, params=None, **kwargs):
+
+    session = requests_retry_session()
+    while True:
+        r = session.get(url, params=params, headers=headers, kwargs)
+        if r.response_code in (503, 419):
+
+        else:
+            return r
+
+
+http_get(

--- a/troi/http_request.py
+++ b/troi/http_request.py
@@ -1,9 +1,12 @@
 import requests
-from time import time
+from time import time, sleep
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from urllib.parse import urlparse
 
-from icecream import ic
+# Index keep track of rate limits of the various services 
+# we may call. key: scheme, domain value: RateLimit-Limit, Remaining, Reset
+domain_ratelimit_lookup = {}
 
 def requests_retry_session(
     retries=3,
@@ -26,35 +29,53 @@ def requests_retry_session(
 
 
 def http_get(url, headers=None, params=None, **kwargs):
+    return http_fetch(url, "GET", headers=headers, params=params, **kwargs)
+
+def http_post(url, headers=None, params=None, **kwargs):
+    return http_fetch(url, "POST", headers=headers, params=params, **kwargs)
+
+def http_fetch(url, method, headers=None, params=None, **kwargs):
 
     if not headers:
         headers = {}
     headers["User-Agent"] = "ListenBrainz Troi (rob@meb)"
 
+    if method not in ("GET", "POST"):
+        raise ValueError("Only GET and POST are supported.")
+
     session = requests_retry_session()
+    parse = urlparse(url)
     while True:
-        # Switch back to session!
-        r = requests.get(url, params=params, headers=headers, **kwargs)
-        print("X-RateLimit-Limit    ", r.headers["X-RateLimit-Limit"])
-        print("X-RateLimit-Remaining", r.headers["X-RateLimit-Remaining"])
-        print("X-RateLimit-Reset    ", r.headers["X-RateLimit-Reset"])
-        reset = int(r.headers["X-RateLimit-Reset"]) - time()
-        if reset < 0:
-            print("reset time            passed")
+        _key = parse.scheme + parse.netloc
+        if _key in domain_ratelimit_lookup:
+            (limit, remaining, reset) = domain_ratelimit_lookup[_key]
+            time_left = reset - time()
+            if time_left > 0:
+                time_to_wait = time_left / remaining
+                sleep(time_to_wait)
+            del domain_ratelimit_lookup[_key]
+
+        if method == "GET":
+            r = session.get(url, params=params, headers=headers, **kwargs)
         else:
-            print("reset time in         %.2f seconds" % reset)
-        print("response code        ", r.status_code)
+            r = session.post(url, params=params, headers=headers, **kwargs)
+
+        reset = int(r.headers["X-RateLimit-Reset"])
+        remaining = int(r.headers["X-RateLimit-Remaining"])
+        limit = int(r.headers["X-RateLimit-Limit"])
+        domain_ratelimit_lookup[_key] = (limit, remaining, reset)
+
+        # This should never happen, but if it does, just retry
         if r.status_code in (503, 419):
-            ic(r.headers)
-        else:
-            return r
+            continue
 
-print("\nLISTENBRAINZ")
-for i in range(10):
-    resp = http_get("https://api.listenbrainz.org/1/metadata/recording?recording_mbids=e97f805a-ab48-4c52-855e-07049142113d")
-    print()
+        return r
 
-print("\nMUSICBRAINZ")
-for i in range(10):
-    resp = http_get("https://musicbrainz.org/ws/2/artist/8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11?fmt=json")
-    print()
+if __name__ == "__main__":
+    print("\nLISTENBRAINZ")
+    for i in range(500):
+        resp = http_get("https://api.listenbrainz.org/1/metadata/recording?recording_mbids=e97f805a-ab48-4c52-855e-07049142113d")
+
+    #print("\nMUSICBRAINZ")
+    #for i in range(10):
+    #    resp = http_get("https://musicbrainz.org/ws/2/artist/8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11?fmt=json")

--- a/troi/http_request.py
+++ b/troi/http_request.py
@@ -1,6 +1,9 @@
 import requests
+from time import time
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+
+from icecream import ic
 
 def requests_retry_session(
     retries=3,
@@ -24,13 +27,34 @@ def requests_retry_session(
 
 def http_get(url, headers=None, params=None, **kwargs):
 
+    if not headers:
+        headers = {}
+    headers["User-Agent"] = "ListenBrainz Troi (rob@meb)"
+
     session = requests_retry_session()
     while True:
-        r = session.get(url, params=params, headers=headers, kwargs)
-        if r.response_code in (503, 419):
-
+        # Switch back to session!
+        r = requests.get(url, params=params, headers=headers, **kwargs)
+        print("X-RateLimit-Limit    ", r.headers["X-RateLimit-Limit"])
+        print("X-RateLimit-Remaining", r.headers["X-RateLimit-Remaining"])
+        print("X-RateLimit-Reset    ", r.headers["X-RateLimit-Reset"])
+        reset = int(r.headers["X-RateLimit-Reset"]) - time()
+        if reset < 0:
+            print("reset time            passed")
+        else:
+            print("reset time in         %.2f seconds" % reset)
+        print("response code        ", r.status_code)
+        if r.status_code in (503, 419):
+            ic(r.headers)
         else:
             return r
 
+print("\nLISTENBRAINZ")
+for i in range(10):
+    resp = http_get("https://api.listenbrainz.org/1/metadata/recording?recording_mbids=e97f805a-ab48-4c52-855e-07049142113d")
+    print()
 
-http_get(
+print("\nMUSICBRAINZ")
+for i in range(10):
+    resp = http_get("https://musicbrainz.org/ws/2/artist/8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11?fmt=json")
+    print()

--- a/troi/listenbrainz/feedback.py
+++ b/troi/listenbrainz/feedback.py
@@ -3,8 +3,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 from time import sleep
 
-import requests
-
+from troi.http_request import http_get
 from troi import Element, Recording
 
 
@@ -44,17 +43,11 @@ class ListensFeedbackLookup(Element):
         for idx in range(0, len(mbids), batch_size):
             recording_mbids = mbids[idx: idx + batch_size]
 
-            while True:
-                response = requests.get(
-                    f"https://api.listenbrainz.org/1/feedback/user/{self.user_name}/get-feedback-for-recordings",
-                    params={"recording_mbids": ",".join(recording_mbids)},
-                    headers=headers
-                )
-                if response.status_code == 429:
-                    sleep(2)
-                    continue
-
-                break
+            response = http_get(
+                f"https://api.listenbrainz.org/1/feedback/user/{self.user_name}/get-feedback-for-recordings",
+                params={"recording_mbids": ",".join(recording_mbids)},
+                headers=headers
+            )
             response.raise_for_status()
             data = response.json()["feedback"]
             if len(data) == 0:

--- a/troi/listenbrainz/listens.py
+++ b/troi/listenbrainz/listens.py
@@ -3,8 +3,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 from time import sleep
 
-import requests
-
+from troi.http_request import http_get
 from troi import Element, Recording
 
 
@@ -45,15 +44,11 @@ class RecentListensTimestampLookup(Element):
         min_ts = int(min_dt.timestamp())
         while True:
             headers = {"Authorization": f"Token {self.auth_token}"} if self.auth_token else {}
-            response = requests.get(
+            response = http_get(
                 f"https://api.listenbrainz.org/1/user/{self.user_name}/listens",
                 params={"min_ts": min_ts, "count": 100},
                 headers=headers
             )
-            if response.status_code == 429:
-                sleep(2)
-                continue
-
             response.raise_for_status()
             data = response.json()["payload"]
             if len(data["listens"]) == 0:

--- a/troi/listenbrainz/recs.py
+++ b/troi/listenbrainz/recs.py
@@ -1,9 +1,11 @@
 import json
+import dateutil.parser
 import requests
-from troi import Element, Recording, PipelineError
+
 import liblistenbrainz
 import liblistenbrainz.errors
-import dateutil.parser
+
+from troi import Element, Recording, PipelineError
 
 MAX_NUM_RECORDINGS_PER_REQUEST = 100
 

--- a/troi/musicbrainz/mbid_mapping.py
+++ b/troi/musicbrainz/mbid_mapping.py
@@ -1,8 +1,8 @@
-import requests
 import ujson
 from time import sleep
 
 from troi import Element, Artist, ArtistCredit, Recording, Release, PipelineError
+import troi.http_request
 
 
 class MBIDMappingLookupElement(Element):
@@ -37,17 +37,9 @@ class MBIDMappingLookupElement(Element):
         if not params:
             return []
 
-        while True:
-            r = requests.post(self.SERVER_URL, json=params)
-            if r.status_code == 429:
-                sleep(2)
-                continue
-
-            if r.status_code != 200:
-                raise PipelineError("Cannot fetch MBID mapping rows from ListenBrainz: HTTP code %d (%s)" % (r.status_code, r.text))
-
-            break
-
+        r = troi.http_request.http_post(self.SERVER_URL, json=params)
+        if r.status_code != 200:
+            raise PipelineError("Cannot fetch MBID mapping rows from ListenBrainz: HTTP code %d (%s)" % (r.status_code, r.text))
 
         entities = []
         for row in r.json():

--- a/troi/musicbrainz/mbid_reader.py
+++ b/troi/musicbrainz/mbid_reader.py
@@ -1,4 +1,3 @@
-import requests
 import ujson
 
 from troi import Element, Recording

--- a/troi/musicbrainz/related_artist_credits.py
+++ b/troi/musicbrainz/related_artist_credits.py
@@ -2,8 +2,7 @@ import copy
 from collections import defaultdict
 from time import sleep
 
-import requests
-
+import troi.http_request
 from troi import Element, Recording, PipelineError, DEVELOPMENT_SERVER_URL
 
 
@@ -33,17 +32,9 @@ class RelatedArtistCreditsElement(Element):
         params = {"[artist_credit_id]": ac_ids,
                   "threshold": self.threshold}
 
-        while True:
-            r = requests.get(self.SERVER_URL, params=params)
-            if r.status_code == 429:
-                sleep(2)
-                continue
-
-            if r.status_code != 200:
-                raise PipelineError("Cannot fetch related artist credits from ListenBrainz: HTTP code %d" % r.status_code)
-
-            break
-
+        r = troi.http_request.http_get(self.SERVER_URL, params=params)
+        if r.status_code != 200:
+            raise PipelineError("Cannot fetch related artist credits from ListenBrainz: HTTP code %d" % r.status_code)
 
         try:
             relations = r.text

--- a/troi/patches/lb_radio.py
+++ b/troi/patches/lb_radio.py
@@ -84,9 +84,10 @@ class LBRadioPatch(troi.patch.Patch):
             return self.lookup_artist_from_mbid(artist_name)
 
         err_msg = f"Artist {artist_name} could not be looked up. Please use exact spelling."
-
+        
+        headers = { "User-Agent": "troi-recommendation-playlist (MetaBrainz)"}
         while True:
-            r = requests.get( f"https://musicbrainz.org/ws/2/artist?query={quote(artist_name)}&fmt=json")
+            r = requests.get( f"https://musicbrainz.org/ws/2/artist?query={quote(artist_name)}&fmt=json", headers=headers)
             if r.status_code == 404:
                 raise RuntimeError(err_msg)
 

--- a/troi/patches/lb_radio_classes/collection.py
+++ b/troi/patches/lb_radio_classes/collection.py
@@ -1,11 +1,10 @@
 from random import shuffle
 from time import sleep
 
-import requests
-
 import troi
 from troi import Recording
 from troi import TARGET_NUMBER_OF_RECORDINGS
+from troi.http_request import http_get
 
 
 class LBRadioCollectionRecordingElement(troi.Element):
@@ -32,19 +31,12 @@ class LBRadioCollectionRecordingElement(troi.Element):
         # Fetch collection recordings
         params = {"collection": self.mbid, "fmt": "json"}
 
-        while True:
-            r = requests.get("https://musicbrainz.org/ws/2/recording", params=params)
-            if r.status_code == 404:
-                raise RuntimeError(f"Cannot find collection {self.mbid}.")
+        r = http_get("https://musicbrainz.org/ws/2/recording", params=params)
+        if r.status_code == 404:
+            raise RuntimeError(f"Cannot find collection {self.mbid}.")
 
-            if r.status_code == 429:
-                sleep(2)
-                continue
-
-            if r.status_code != 200:
-                raise RuntimeError(f"Cannot fetch collection {self.mbid}. {r.text}")
-
-            break
+        if r.status_code != 200:
+            raise RuntimeError(f"Cannot fetch collection {self.mbid}. {r.text}")
 
         # Give feedback about what we collected
         self.local_storage["data_cache"]["element-descriptions"].append(f"collection {self.mbid}")

--- a/troi/patches/lb_radio_classes/playlist.py
+++ b/troi/patches/lb_radio_classes/playlist.py
@@ -2,10 +2,9 @@ import troi
 from time import sleep
 from random import shuffle
 
-import requests
-
 from troi import Recording
 from troi import TARGET_NUMBER_OF_RECORDINGS
+from troi.http_request import http_get
 
 
 class LBRadioPlaylistRecordingElement(troi.Element):
@@ -30,17 +29,11 @@ class LBRadioPlaylistRecordingElement(troi.Element):
     def read(self, entities):
 
         # Fetch the playlist
-        while True:
-            r = requests.get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
-            if r.status_code == 404:
-                raise RuntimeError(f"Cannot find playlist {self.mbid}.")
-            if r.status_code == 429:
-                sleep(2)
-                continue
-            if r.status_code != 200:
-                raise RuntimeError(f"Cannot fetch playlist {self.mbid}. {r.text}")
-
-            break
+        r = http_get(f"https://api.listenbrainz.org/1/playlist/{self.mbid}")
+        if r.status_code == 404:
+            raise RuntimeError(f"Cannot find playlist {self.mbid}.")
+        if r.status_code != 200:
+            raise RuntimeError(f"Cannot fetch playlist {self.mbid}. {r.text}")
 
         # Give feedback about the playlist
         self.local_storage["data_cache"]["element-descriptions"].append(f"playlist {self.mbid}")

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -3,11 +3,10 @@ from time import sleep
 import troi
 from random import randint, shuffle
 
-import requests
-
 from troi import Recording
 from troi.plist import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
+from troi.http_request import http_get
 
 
 class LBRadioTagRecordingElement(troi.Element):
@@ -36,19 +35,12 @@ class LBRadioTagRecordingElement(troi.Element):
             Fetch similar tags from LB
         """
 
-        while True:
-            r = requests.post("https://labs.api.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
-            if r.status_code == 429:
-                sleep(2)
-                continue
+        r = http_post("https://labs.api.listenbrainz.org/tag-similarity/json", json=[{"tag": tag}])
+        if r.status_code == 404:
+            return plist()
 
-            if r.status_code == 404:
-                return plist()
-
-            if r.status_code != 200:
-                raise RuntimeError(f"Cannot fetch similar tags. {r.text}")
-
-            break
+        if r.status_code != 200:
+            raise RuntimeError(f"Cannot fetch similar tags. {r.text}")
 
         return plist(r.json())
 

--- a/troi/patches/lb_radio_classes/tag.py
+++ b/troi/patches/lb_radio_classes/tag.py
@@ -6,7 +6,7 @@ from random import randint, shuffle
 from troi import Recording
 from troi.plist import plist
 from troi import TARGET_NUMBER_OF_RECORDINGS
-from troi.http_request import http_get
+from troi.http_request import http_post
 
 
 class LBRadioTagRecordingElement(troi.Element):

--- a/troi/tools/apple_lookup.py
+++ b/troi/tools/apple_lookup.py
@@ -1,8 +1,8 @@
 import logging
-import requests
 
 from .utils import AppleMusicAPI, AppleMusicException
 from more_itertools import chunked
+from troi.http_request import http_post
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ APPLE_MUSIC_IDS_LOOKUP_URL = "https://labs.api.listenbrainz.org/apple-music-id-f
 def lookup_apple_music_ids(recordings):
     """ Given a list of Recording elements, try to find Apple Music track ids from labs api apple_music_id lookup_from_mbid
     and add those to the recordings. """
-    response = requests.post(
+    response = http_post(
         APPLE_MUSIC_IDS_LOOKUP_URL,
         json=[{"recording_mbid": recording.mbid} for recording in recordings]
     )

--- a/troi/tools/area_lookup.py
+++ b/troi/tools/area_lookup.py
@@ -1,8 +1,8 @@
-import requests
 from time import sleep
 import ujson
 
 from troi import PipelineError, DEVELOPMENT_SERVER_URL
+import troi.http_request
 
 AREA_LOOKUP_SERVER_URL = DEVELOPMENT_SERVER_URL + "/area-lookup/json"
 def area_lookup(area_name):
@@ -11,15 +11,9 @@ def area_lookup(area_name):
     '''
 
     data = [ { '[area]': area_name } ]
-    while True:
-        r = requests.post(AREA_LOOKUP_SERVER_URL, json=data)
-        if r.status_code == 429:
-            sleep(2)
-            continue
-        if r.status_code != 200:
-            raise PipelineError("Cannot lookup area name. " + str(r.text))
-
-        break
+    r = troi.http_request.http_post(AREA_LOOKUP_SERVER_URL, json=data)
+    if r.status_code != 200:
+        raise PipelineError("Cannot lookup area name. " + str(r.text))
 
     try:
         rows = ujson.loads(r.text)

--- a/troi/tools/common_lookup.py
+++ b/troi/tools/common_lookup.py
@@ -1,11 +1,11 @@
 import logging
 
-import requests
 from more_itertools import chunked
 
 from troi.tools.apple_lookup import get_tracks_from_apple_playlist
 from troi.tools.spotify_lookup import get_tracks_from_spotify_playlist
 from troi.tools.soundcloud_lookup import get_tracks_from_soundcloud_playlist
+from troi.http_request import http_post
 
 MAX_LOOKUPS_PER_POST = 50
 MBID_LOOKUP_URL = "https://api.listenbrainz.org/1/metadata/lookup/"
@@ -37,7 +37,7 @@ def mbid_mapping_tracks(track_lists):
         params = {
             "recordings": tracks
         }
-        response = requests.post(MBID_LOOKUP_URL, json=params)
+        response = http_post(MBID_LOOKUP_URL, json=params)
         if response.status_code == 200:
             data = response.json()
             for d in data:

--- a/troi/tools/soundcloud_lookup.py
+++ b/troi/tools/soundcloud_lookup.py
@@ -1,9 +1,9 @@
-import requests
 import logging
 
 from collections import defaultdict
 from more_itertools import chunked
 from .utils import SoundcloudAPI, SoundCloudException
+from troi.http_request import http_post
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ SOUNDCLOUD_IDS_LOOKUP_URL = "https://labs.api.listenbrainz.org/soundcloud-id-fro
 def lookup_soundcloud_ids(recordings):
     """ Given a list of Recording elements, try to find soundcloud track ids from labs api soundcloud lookup using mbids
     and add those to the recordings. """
-    response = requests.post(
+    response = http_post(
         SOUNDCLOUD_IDS_LOOKUP_URL,
         json=[{"recording_mbid": recording.mbid} for recording in recordings]
     )

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -1,10 +1,11 @@
 import logging
 from collections import defaultdict
 import re
-import requests
 import spotipy
 from more_itertools import chunked
 from spotipy import SpotifyException
+
+from troi.http_request import http_post
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ CLEAN_HTML_RE = re.compile('<.*?>')
 def lookup_spotify_ids(recordings):
     """ Given a list of Recording elements, try to find spotify track ids from labs api spotify lookup using mbids
     and add those to the recordings. """
-    response = requests.post(
+    response = http_post(
         SPOTIFY_IDS_LOOKUP_URL,
         json=[{"recording_mbid": recording.mbid} for recording in recordings]
     )


### PR DESCRIPTION
Using an HTTP session and a new rate limit http fetching module ensures that all requests are timed to not overload any of the APIs we're calling. Hack for MB is in place and will need to be removed once MB's RateLimit headers start working correctly. 

related: https://tickets.metabrainz.org/browse/MBH-589