### PR TITLE
Add logging functions to support third party apps

### DIFF
--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -18,7 +18,7 @@ logging.addLevelName(APP_LOG_LEVEL_NUM, "NOTICE")
 
 def applog(message, *args, **kwargs):
     if logger.isEnabledFor(APP_LOG_LEVEL_NUM):
-        self._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
+        logger._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
 
 def logboth(message, *args, **kwargs):
     if logger.isEnabledFor(APP_LOG_LEVEL_NUM):

--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -16,18 +16,15 @@ logger = logging.getLogger("troi_subsonic_scan")
 APP_LOG_LEVEL_NUM = 19
 logging.addLevelName(APP_LOG_LEVEL_NUM, "NOTICE")
 
-def applog(self, message, *args, **kwargs):
-    if self.isEnabledFor(APP_LOG_LEVEL_NUM):
+def applog(message, *args, **kwargs):
+    if logger.isEnabledFor(APP_LOG_LEVEL_NUM):
         self._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
 
-def logboth(self, message, *args, **kwargs):
-    if self.isEnabledFor(APP_LOG_LEVEL_NUM):
-        self._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
-    if self.isEnabledFor(logging.INFO):
-        self._log(logging.INFO, message, args, **kwargs)
-
-logger.applog = applog
-logger.logboth = logboth
+def logboth(message, *args, **kwargs):
+    if logger.isEnabledFor(APP_LOG_LEVEL_NUM):
+        logger._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
+    if logger.isEnabledFor(logging.INFO):
+        logger._log(logging.INFO, message, args, **kwargs)
 
 
 class SubsonicDatabase(Database):

--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -20,12 +20,6 @@ def applog(message, *args, **kwargs):
     if logger.isEnabledFor(APP_LOG_LEVEL_NUM):
         logger._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
 
-def logboth(message, *args, **kwargs):
-    if logger.isEnabledFor(APP_LOG_LEVEL_NUM):
-        logger._log(APP_LOG_LEVEL_NUM, message, args, **kwargs)
-    if logger.isEnabledFor(logging.INFO):
-        logger._log(logging.INFO, message, args, **kwargs)
-
 
 class SubsonicDatabase(Database):
     '''

--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -52,9 +52,9 @@ class SubsonicDatabase(Database):
 
         self.run_sync()
 
-        logboth("Checked %s albums:" % self.total)
-        logboth("  %5d albums matched" % self.matched)
-        logboth("  %5d recordings with errors" % self.error)
+        logger.info("Checked %s albums:" % self.total)
+        logger.info("  %5d albums matched" % self.matched)
+        logger.info("  %5d recordings with errors" % self.error)
 
     def connect(self):
         if not self.config:
@@ -81,7 +81,7 @@ class SubsonicDatabase(Database):
 
         cursor = db.connection().cursor()
 
-        logboth("[ load albums ]")
+        logger.info("[ load albums ]")
         album_ids = set()
         albums = []
         offset = 0
@@ -95,7 +95,7 @@ class SubsonicDatabase(Database):
             if album_count < self.BATCH_SIZE:
                 break
 
-        logboth("[ loaded %d albums ]" % len(album_ids))
+        logger.info("[ loaded %d albums ]" % len(album_ids))
 
         if not self.quiet:
             pbar = tqdm(total=len(album_ids))

--- a/troi/content_resolver/subsonic.py
+++ b/troi/content_resolver/subsonic.py
@@ -11,7 +11,7 @@ from troi.content_resolver.model.recording import Recording, FileIdType
 from troi.content_resolver.utils import bcolors
 from troi.content_resolver.py_sonic_fix import FixedConnection
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("troi_subsonic_scan")
 
 
 class SubsonicDatabase(Database):


### PR DESCRIPTION
Right now all output about scanning a subsonic collection goes to stdout, which is worthless for a web app like lb-local. Naming the logger and adding a new logging level that this output goes to allows third parties to tap into better logging facilities in troi.