### PR TITLE
Update spotipy, python reqs, dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 description="ListenBrainz' empathic music recommendation/playlisting engine"
 readme = "README.md"
-requires-python=">=3.9"
+requires-python=">=3.10"
 classifiers=[
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
@@ -25,7 +25,7 @@ dependencies = [
   'regex>=2023.6.3',
   'requests>=2.31.0',
   'scikit-learn>=1.2.1',
-  'spotipy>=2.22.1',
+  'spotipy>=2.26.0',
   'tqdm',
   'ujson>=5.4.0',
   'Unidecode>=1.3.6',
@@ -39,19 +39,19 @@ nmslib = [
   'nmslib-metabrainz>=2.1.1'
 ]
 tests = [
-  'pytest == 7.1.2',
-  'pytest-cov == 4.1.0',
-  'requests-mock == 1.11.0'
+  'pytest == 9.0.2',
+  'pytest-cov == 7.0.0',
+  'requests-mock == 1.12.1'
 ]
 build = [
   'build'
 ]
 docs = [
-  'Sphinx == 5.0.2',
-  'sphinxcontrib-httpdomain == 1.8.0',
-  'sphinx_rtd_theme == 0.5.1',
-  'docutils == 0.17.1',
-  'sphinx-click == 4.3.0'
+  'Sphinx == 8.1.3',
+  'sphinxcontrib-httpdomain == 2.0.0',
+  'sphinx_rtd_theme == 3.1.0',
+  'docutils == 0.21.2',
+  'sphinx-click == 6.2.0'
 ]
 
 [project.urls]

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -85,7 +85,7 @@ class TestSpotifySubmission(unittest.TestCase):
             }
         ])
 
-        mock_requests.post("https://api.spotify.com/v1/users/test-user-id/playlists", json={
+        mock_requests.post("https://api.spotify.com/v1/me/playlists", json={
             "id": playlist_id,
             "external_urls": {
                 "spotify": playlist_url

--- a/troi/cli.py
+++ b/troi/cli.py
@@ -51,7 +51,6 @@ cli.add_command(resolver_cli, name="db")
 @click.option('--name', '-n', help="Override the default name of the generated playlist", required=False)
 @click.option('--desc', '-d', help="Override the default description of the generated playlist", required=False)
 @click.option('--min-recordings', '-m', help="The minimum number of playlist required for the playlist", type=int, required=False)
-@click.option('--spotify-user-id', help="The spotify user name to upload the playlist to", type=str, required=False)
 @click.option('--spotify-token',
               help="The spotify token with the correct permissions required to upload playlists",
               type=str,
@@ -85,7 +84,7 @@ cli.add_command(resolver_cli, name="db")
               multiple=True)
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def playlist(patch, quiet, save, token, upload, args, created_for, name, desc, min_recordings,
-             spotify_user_id, spotify_token, spotify_url, soundcloud_token, soundcloud_url,
+             spotify_token, spotify_url, soundcloud_token, soundcloud_url,
              apple_music_developer_token, apple_music_user_token, apple_music_url):
     """
     Generate a global MBID based playlist using a patch
@@ -110,7 +109,6 @@ def playlist(patch, quiet, save, token, upload, args, created_for, name, desc, m
     }
     if spotify_token:
         patch_args["spotify"] = {
-            "user_id": spotify_user_id,
             "token": spotify_token,
             "is_public": True,
             "is_collaborative": False,

--- a/troi/patch.py
+++ b/troi/patch.py
@@ -187,7 +187,6 @@ class Patch(ABC):
         save = self.patch_args["save"]
         if result is not None and spotify and upload:
             for url, _ in playlist.submit_to_spotify(
-                spotify["user_id"],
                 spotify["token"],
                 spotify["is_public"],
                 spotify["is_collaborative"],

--- a/troi/playlist.py
+++ b/troi/playlist.py
@@ -299,7 +299,6 @@ class PlaylistElement(Element):
         return playlist_mbids
 
     def submit_to_spotify(self,
-                          user_id: str,
                           token: str,
                           is_public: bool = True,
                           is_collaborative: bool = False,
@@ -320,7 +319,7 @@ class PlaylistElement(Element):
             if existing_urls and idx < len(existing_urls) and existing_urls[idx]:
                 existing_url = existing_urls[idx]
 
-            playlist_url, playlist_id = submit_to_spotify(sp, playlist, user_id, is_public, is_collaborative, existing_url)
+            playlist_url, playlist_id = submit_to_spotify(sp, playlist, is_public, is_collaborative, existing_url)
             submitted.append((playlist_url, playlist_id))
 
         return submitted

--- a/troi/tools/spotify_lookup.py
+++ b/troi/tools/spotify_lookup.py
@@ -121,7 +121,7 @@ def fixup_spotify_playlist(sp: spotipy.Spotify, playlist_id: str, mbid_spotify_i
         sp.playlist_add_items(playlist_id, chunk)
 
 
-def submit_to_spotify(spotify, playlist, spotify_user_id: str, is_public: bool = True,
+def submit_to_spotify(spotify, playlist, is_public: bool = True,
                       is_collaborative: bool = False, existing_url: str = None):
     """ Submit or update an existing spotify playlist.
 
@@ -160,8 +160,7 @@ def submit_to_spotify(spotify, playlist, spotify_user_id: str, is_public: bool =
 
     if not playlist_id:
         # create new playlist
-        spotify_playlist = spotify.user_playlist_create(
-            user=spotify_user_id,
+        spotify_playlist = spotify.current_user_playlist_create(
             name=playlist_name,
             public=is_public,
             collaborative=is_collaborative,


### PR DESCRIPTION
Update spotipy to replace use of deprecated APIs. Update minimum python requirements and other dev dependencies.

spotify_user_id is not used by the spotify API anymore and hence removed from the submit_to_spotify and PlaylistElement.